### PR TITLE
install bin/cachetool when used as library or global

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,6 @@
     },
     "require-dev": {
         "herrera-io/phar-update": "~2.0"
-    }
+    },
+    "bin": ["bin/cachetool"]
 }


### PR DESCRIPTION
so when run with composer require, you'll end up with bin/cachetool