### PR TITLE
update bin/cachetool to include global autoloader

### DIFF
--- a/bin/cachetool
+++ b/bin/cachetool
@@ -3,6 +3,17 @@
 
 require __DIR__.'/../vendor/autoload.php';
 
+$autoloadFiles = array(
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php'
+);
+foreach ($autoloadFiles as $autoloadFile) {
+    if (file_exists($autoloadFile)) {
+        require_once $autoloadFile;
+    }
+}
+
+
 use CacheTool\Console\Application;
 use CacheTool\Console\Config;
 use Symfony\Component\Yaml\Yaml;


### PR DESCRIPTION
bin/cachetool must use the global autoloader too if it exists, otherwise the command cannot find it.

I grabbed this from how bin/doctrine.php works