### PR TITLE
Fix adoy/fastcgi-client composer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "symfony/yaml": "~2.1",
         "psr/log": "~1.0",
         "monolog/monolog": "~1.1",
-        "adoy/fastcgi-client": "dev-master#c332dfc8d3f96e47022170f169de73cf8d8d4f0a"
+        "adoy/fastcgi-client": "~1.0"
     },
     "require-dev": {
         "herrera-io/phar-update": "~2.0"


### PR DESCRIPTION
When I'm installing cachetool with composer, I've got this issue:

```
deploy@server:~$ composer global require gordalina/cachetool
Changed current directory to /home/deploy/.composer
Using version ^1.9 for gordalina/cachetool
./composer.json has been created
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for gordalina/cachetool ^1.9 -> satisfiable by gordalina/cachetool[1.9.0].
    - gordalina/cachetool 1.9.0 requires adoy/fastcgi-client dev-master#c332dfc8d3f96e47022170f169de73cf8d8d4f0a -> no matching package found.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.

Installation failed, deleting ./composer.json.
```

The version 1.0 has been released, so I've updated the composer.json with the proper version.