### PR TITLE
Add support for viewing/manipulating the file status cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Why is this useful?
 - Maybe you want to see some statistics right from the console
 - And many more...
 
+Note that, unlike APC and Opcache, the file status cache is per-process rather than stored in shared memory. This means that running `stat:clear` against PHP-FPM will only affect whichever FPM worker responds to the request, not the whole pool. [Julien Pauli has written a post](http://jpauli.github.io/2014/06/30/realpath-cache.html) with more details on the file status cache operates.
+
 Installation
 ------------
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CacheTool - Manage cache in the CLI
 [![SensioLabsInsight](https://img.shields.io/sensiolabs/i/595c9feb-3f4d-473a-a575-81c7e97eb672.svg)](https://insight.sensiolabs.com/projects/595c9feb-3f4d-473a-a575-81c7e97eb672)
 [![Codacy Badge](https://img.shields.io/codacy/2d4176f2526d4251a51b691249c4d3e1.svg)](https://www.codacy.com)
 
-CacheTool allows you to work with `apc` and `opcache` through the cli.
+CacheTool allows you to work with `apc`, `opcache`, and the file status cache through the cli.
 It will connect to a fastcgi server (like php-fpm) and operate it's cache.
 
 Why is this useful?
@@ -70,6 +70,10 @@ opcache
   opcache:reset            Resets the contents of the opcode cache
   opcache:status           Show summary information about the opcode cache
   opcache:status:scripts   Show scripts in the opcode cache
+stat
+  stat:clear               Clears the file status cache, including the realpath cache
+  stat:realpath_get        Show summary information of realpath cache entries
+  stat:realpath_size       Display size of realpath cache
 ```
 
 Configuration File

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Why is this useful?
 - Maybe you want to see some statistics right from the console
 - And many more...
 
-Note that, unlike APC and Opcache, the file status cache is per-process rather than stored in shared memory. This means that running `stat:clear` against PHP-FPM will only affect whichever FPM worker responds to the request, not the whole pool. [Julien Pauli has written a post](http://jpauli.github.io/2014/06/30/realpath-cache.html) with more details on the file status cache operates.
+Note that, unlike APC and Opcache, the file status cache is per-process rather than stored in shared memory. This means that running `stat:clear` against PHP-FPM will only affect whichever FPM worker responds to the request, not the whole pool. [Julien Pauli has written a post](http://jpauli.github.io/2014/06/30/realpath-cache.html) with more details on how the file status cache operates.
 
 Installation
 ------------

--- a/src/CacheTool/Command/StatCacheClearCommand.php
+++ b/src/CacheTool/Command/StatCacheClearCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of CacheTool.
+ *
+ * (c) Samuel Gordalina <samuel.gordalina@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CacheTool\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class StatCacheClearCommand extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('stat:clear')
+            ->setDescription('Clears the file status cache, including the realpath cache')
+            ->setHelp('');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->getCacheTool()->stat_cache_clear();
+    }
+}

--- a/src/CacheTool/Command/StatRealpathGetCommand.php
+++ b/src/CacheTool/Command/StatRealpathGetCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of CacheTool.
+ *
+ * (c) Samuel Gordalina <samuel.gordalina@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CacheTool\Command;
+
+use CacheTool\Util\Formatter;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class StatRealpathGetCommand extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('stat:realpath_get')
+            ->setDescription('Show summary information of realpath cache entries')
+            ->setHelp('');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $info = $this->getCacheTool()->stat_realpath_get();
+
+        $table = $this->getHelper('table');
+        $table
+            ->setHeaders(array(
+                'Path entry',
+                'key',
+                'is_dir',
+                'realpath',
+                'expires',
+            ))
+            ->setRows($this->processFilelist($info))
+        ;
+
+        $table->render($output);
+    }
+
+    protected function processFileList(array $cacheList)
+    {
+        $list = array();
+
+        foreach ($cacheList as $path_entry => $item) {
+            $list[] = array(
+               $path_entry,
+               $item['key'],
+               $item['is_dir'],
+               $item['realpath'],
+               $item['expires'],
+            );
+        }
+
+        return $list;
+    }
+}

--- a/src/CacheTool/Command/StatRealpathSizeCommand.php
+++ b/src/CacheTool/Command/StatRealpathSizeCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of CacheTool.
+ *
+ * (c) Samuel Gordalina <samuel.gordalina@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CacheTool\Command;
+
+use CacheTool\Util\Formatter;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class StatRealpathSizeCommand extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('stat:realpath_size')
+            ->setDescription('Display size of realpath cache')
+            ->setHelp('');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $size = $this->getCacheTool()->stat_realpath_size();
+        $output->writeln(sprintf("<comment>Realpath cache size: <info>%s</info></comment>", Formatter::bytes($size)));
+    }
+}

--- a/src/CacheTool/Console/Application.php
+++ b/src/CacheTool/Console/Application.php
@@ -77,6 +77,10 @@ class Application extends BaseApplication
         $commands[] = new CacheToolCommand\OpcacheStatusScriptsCommand();
         $commands[] = new CacheToolCommand\OpcacheInvalidateScriptsCommand();
 
+        $commands[] = new CacheToolCommand\StatCacheClearCommand();
+        $commands[] = new CacheToolCommand\StatRealpathGetCommand();
+        $commands[] = new CacheToolCommand\StatRealpathSizeCommand();
+
         return $commands;
     }
 

--- a/src/CacheTool/Proxy/PhpProxy.php
+++ b/src/CacheTool/Proxy/PhpProxy.php
@@ -31,6 +31,9 @@ class PhpProxy implements ProxyInterface
             'ini_get',
             'ini_set',
             'phpversion',
+            'stat_realpath_get',
+            'stat_realpath_size',
+            'stat_cache_clear',
 
             '_eval',
         );
@@ -116,6 +119,48 @@ class PhpProxy implements ProxyInterface
         return $this->adapter->run($code);
     }
 
+    /**
+     * Get contents of the realpath cache
+     *
+     * @since  5.3.2
+     * @return array Returns an array of realpath cache entries. The keys are original path entries, 
+     * and the values are arrays of data items, containing the resolved path, expiration date, and 
+     * other options kept in the cache.
+     */
+    public function stat_realpath_get()
+    {
+        $code = new Code();
+        $code->addStatement('return realpath_cache_get();');
+
+        return $this->adapter->run($code);
+    }
+
+    /**
+     * Returns how much memory realpath cache is using. 
+     *
+     * @since  5.3.2
+     * @return int Memory usage in bytes
+     */
+    public function stat_realpath_size()
+    {
+        $code = new Code();
+        $code->addStatement('return realpath_cache_size();');
+
+        return $this->adapter->run($code);
+    }
+
+    /**
+     * Resets the contents of the file status cache, including the realpath cache
+     *
+     * @return void
+     */
+    public function stat_cache_clear()
+    {
+        $code = new Code();
+        $code->addStatement('return clearstatcache(true);');
+
+        return $this->adapter->run($code);
+    }
 
     /**
      * Evaluate a string as PHP code

--- a/tests/CacheTool/Proxy/PhpProxyTest.php
+++ b/tests/CacheTool/Proxy/PhpProxyTest.php
@@ -6,7 +6,7 @@ class PhpProxyTest extends ProxyTest
 {
     public function testGetFunctions()
     {
-        $this->assertCount(5, $this->createProxyInstance()->getFunctions());
+        $this->assertCount(8, $this->createProxyInstance()->getFunctions());
     }
 
     public function testFunctions()
@@ -16,6 +16,9 @@ class PhpProxyTest extends ProxyTest
         $this->assertProxyCode("return ini_set('var', 'value');", 'ini_set', array('var', 'value'));
         $this->assertProxyCode("return phpversion('php');", 'phpversion', array('php'));
         $this->assertProxyCode("passthru", '_eval', array('passthru'));
+        $this->assertProxyCode('return realpath_cache_get();', 'stat_realpath_get', array());
+        $this->assertProxyCode('return realpath_cache_size();', 'stat_realpath_size', array());
+        $this->assertProxyCode('return clearstatcache(true);', 'stat_cache_clear', array());
     }
 
     protected function createProxyInstance()


### PR DESCRIPTION
PHP's file status cache can be the source of some very tricky problems, as the following post
explains: http://jpauli.github.io/2014/06/30/realpath-cache.html