### PR TITLE
Replace the deprecated TableHelper with the Table class

### DIFF
--- a/src/CacheTool/Command/ApcCacheInfoCommand.php
+++ b/src/CacheTool/Command/ApcCacheInfoCommand.php
@@ -12,6 +12,7 @@
 namespace CacheTool\Command;
 
 use CacheTool\Util\Formatter;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -63,7 +64,7 @@ class ApcCacheInfoCommand extends AbstractCommand
             throw new \RuntimeException("Could not fetch info from APC");
         }
 
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table->setHeaders(array('Name', 'User', 'System'));
         $table->setRows($this->getRows($user, $system));
         $table->render($output);

--- a/src/CacheTool/Command/ApcCacheInfoFileCommand.php
+++ b/src/CacheTool/Command/ApcCacheInfoFileCommand.php
@@ -12,6 +12,7 @@
 namespace CacheTool\Command;
 
 use CacheTool\Util\Formatter;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -50,7 +51,7 @@ class ApcCacheInfoFileCommand extends ApcCacheInfoCommand
             'Filename',
         );
 
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table
             ->setHeaders($header)
             ->setRows($this->processFilelist($info['cache_list']))

--- a/src/CacheTool/Command/ApcRegexpDeleteCommand.php
+++ b/src/CacheTool/Command/ApcRegexpDeleteCommand.php
@@ -11,6 +11,7 @@
 
 namespace CacheTool\Command;
 
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -48,7 +49,7 @@ class ApcRegexpDeleteCommand extends AbstractCommand
             }
         }
         $cpt = 0;
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table->setHeaders(array('Key', 'TTL', ));
         $table->setRows($keys);
         $table->render($output);

--- a/src/CacheTool/Command/OpcacheConfigurationCommand.php
+++ b/src/CacheTool/Command/OpcacheConfigurationCommand.php
@@ -11,6 +11,7 @@
 
 namespace CacheTool\Command;
 
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -38,7 +39,7 @@ class OpcacheConfigurationCommand extends AbstractCommand
 
         $output->writeln("<info>{$info['version']['opcache_product_name']}</info> <comment>{$info['version']['version']}</comment>");
 
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table
             ->setHeaders(array('Directive', 'Value'))
             ->setRows($this->processDirectives($info['directives']))

--- a/src/CacheTool/Command/OpcacheInvalidateScriptsCommand.php
+++ b/src/CacheTool/Command/OpcacheInvalidateScriptsCommand.php
@@ -12,6 +12,7 @@
 namespace CacheTool\Command;
 
 use CacheTool\Util\Formatter;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -44,7 +45,7 @@ class OpcacheInvalidateScriptsCommand extends AbstractCommand
             throw new \RuntimeException('opcache_get_status(): No Opcache status info available.  Perhaps Opcache is disabled via opcache.enable or opcache.enable_cli?');
         }
 
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table
             ->setHeaders(array(
                 'Cleaned',

--- a/src/CacheTool/Command/OpcacheStatusCommand.php
+++ b/src/CacheTool/Command/OpcacheStatusCommand.php
@@ -12,6 +12,7 @@
 namespace CacheTool\Command;
 
 use CacheTool\Util\Formatter;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,7 +43,7 @@ class OpcacheStatusCommand extends AbstractCommand
             throw new \RuntimeException('opcache_get_status(): No Opcache status info available.  Perhaps Opcache is disabled via opcache.enable or opcache.enable_cli?');
         }
 
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table->setHeaders(array('Name', 'Value'));
         $table->setRows($this->getRows($info, $info['opcache_statistics']));
         $table->render($output);

--- a/src/CacheTool/Command/OpcacheStatusScriptsCommand.php
+++ b/src/CacheTool/Command/OpcacheStatusScriptsCommand.php
@@ -12,6 +12,7 @@
 namespace CacheTool\Command;
 
 use CacheTool\Util\Formatter;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -41,7 +42,7 @@ class OpcacheStatusScriptsCommand extends AbstractCommand
             throw new \RuntimeException('opcache_get_status(): No Opcache status info available.  Perhaps Opcache is disabled via opcache.enable or opcache.enable_cli?');
         }
 
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table
             ->setHeaders(array(
                 'Hits',

--- a/src/CacheTool/Command/StatRealpathGetCommand.php
+++ b/src/CacheTool/Command/StatRealpathGetCommand.php
@@ -12,6 +12,7 @@
 namespace CacheTool\Command;
 
 use CacheTool\Util\Formatter;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -36,7 +37,7 @@ class StatRealpathGetCommand extends AbstractCommand
     {
         $info = $this->getCacheTool()->stat_realpath_get();
 
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table
             ->setHeaders(array(
                 'Path entry',


### PR DESCRIPTION
Cachetool 2.x requires `symfony/console ~3.0`, but [TableHelper was deprecated in Symfony 2.5 and removed in Symfony 3.0](http://symfony.com/doc/current/components/console/helpers/tablehelper.html), so it must be replaced with the [Table class](http://symfony.com/doc/current/components/console/helpers/table.html).

This fixes #26.