### PR TITLE
Included previous exception when \RuntimeException is thrown from another exception

### DIFF
--- a/src/CacheTool/Adapter/FastCGI.php
+++ b/src/CacheTool/Adapter/FastCGI.php
@@ -100,7 +100,8 @@ class FastCGI extends AbstractAdapter
 
             throw new \RuntimeException(
                 sprintf('FastCGI error: %s (%s)', $e->getMessage(), $this->host),
-                $e->getCode()
+                $e->getCode(),
+                $e
             );
         }
     }


### PR DESCRIPTION
When the fastCGI client throws an exception, the fastCGI adapter throws a \RuntimeException but doesn't link to the previous exception.

This pull request is about adding the parent exception when throwing the \RuntimeException.

It would permit to check the parent Exception, in my case I'm interested by the ForbiddenException triggered by the **adoy/PHP-FastCGI-Client** in order to do specific stuff.

Could it be possible to integrate this also on the 1.x branch and create a new tag, or do I need to do another PR based on the 1.x branch ?