### PR TITLE
Fix apc_add, apc_store key exception

### DIFF
--- a/src/CacheTool/Proxy/ApcProxy.php
+++ b/src/CacheTool/Proxy/ApcProxy.php
@@ -80,7 +80,7 @@ class ApcProxy implements ProxyInterface
      */
     public function apc_add($key, $var = null, $ttl = 0)
     {
-        if (is_array($key) && $var === null) {
+        if (is_string($key) && $var === null) {
             throw new \InvalidArgumentException('When $key is set $var cannot be null');
         }
 
@@ -516,7 +516,7 @@ class ApcProxy implements ProxyInterface
      */
     public function apc_store($key, $var = null, $ttl = 0)
     {
-        if (is_array($key) && $var === null) {
+        if (is_string($key) && $var === null) {
             throw new \InvalidArgumentException('When $key is set $var cannot be null');
         }
 

--- a/tests/CacheTool/Proxy/ApcProxyTest.php
+++ b/tests/CacheTool/Proxy/ApcProxyTest.php
@@ -32,7 +32,6 @@ class ApcProxyTest extends ProxyTest
     public function testFunctions()
     {
         $this->assertProxyCode("return apc_add('key', 'var', 0);", 'apc_add', array('key', 'var', 0));
-        $this->assertProxyCode("return apc_add(array('array_key' => 'array_var'), NULL, 0);", 'apc_add', array(array('array_key' => 'array_var'), NULL, 0));
         $this->assertProxyCode("return apc_bin_dump(NULL, NULL);", 'apc_bin_dump', array(NULL, NULL));
         $this->assertProxyCode("return apc_bin_dumpfile(array (\n), array (\n), 'filename', 0, NULL);", 'apc_bin_dumpfile', array(array(), array(), 'filename', 0, NULL));
         $this->assertProxyCode("return apc_bin_load('data', 0);", 'apc_bin_load', array('data', 0));
@@ -48,7 +47,6 @@ class ApcProxyTest extends ProxyTest
         $this->assertProxyCode("return apc_load_constants('key', true);", 'apc_load_constants', array('key', true));
         $this->assertProxyCode("return apc_sma_info(false);", 'apc_sma_info', array(false));
         $this->assertProxyCode("return apc_store('key', 'var', 0);", 'apc_store', array('key', 'var', 0));
-        $this->assertProxyCode("return apc_store(array('array_key' => 'array_var'), NULL, 0);", 'apc_store', array(array('array_key' => 'array_var'), NULL, 0));
         $this->assertProxyCode('return phpversion("apc");', 'apc_version', array());
     }
 

--- a/tests/CacheTool/Proxy/ApcProxyTest.php
+++ b/tests/CacheTool/Proxy/ApcProxyTest.php
@@ -17,7 +17,7 @@ class ApcProxyTest extends ProxyTest
     public function testApcAddException()
     {
         $proxy = $this->createProxyInstance();
-        $proxy->apc_add(array(), null);
+        $proxy->apc_add('key', null);
     }
 
     /**
@@ -26,12 +26,13 @@ class ApcProxyTest extends ProxyTest
     public function testApcStoreException()
     {
         $proxy = $this->createProxyInstance();
-        $proxy->apc_store(array(), null);
+        $proxy->apc_store('key', null);
     }
 
     public function testFunctions()
     {
         $this->assertProxyCode("return apc_add('key', 'var', 0);", 'apc_add', array('key', 'var', 0));
+        $this->assertProxyCode("return apc_add(array('array_key' => 'array_var'), NULL, 0);", 'apc_add', array(array('array_key' => 'array_var'), NULL, 0));
         $this->assertProxyCode("return apc_bin_dump(NULL, NULL);", 'apc_bin_dump', array(NULL, NULL));
         $this->assertProxyCode("return apc_bin_dumpfile(array (\n), array (\n), 'filename', 0, NULL);", 'apc_bin_dumpfile', array(array(), array(), 'filename', 0, NULL));
         $this->assertProxyCode("return apc_bin_load('data', 0);", 'apc_bin_load', array('data', 0));
@@ -47,6 +48,7 @@ class ApcProxyTest extends ProxyTest
         $this->assertProxyCode("return apc_load_constants('key', true);", 'apc_load_constants', array('key', true));
         $this->assertProxyCode("return apc_sma_info(false);", 'apc_sma_info', array(false));
         $this->assertProxyCode("return apc_store('key', 'var', 0);", 'apc_store', array('key', 'var', 0));
+        $this->assertProxyCode("return apc_store(array('array_key' => 'array_var'), NULL, 0);", 'apc_store', array(array('array_key' => 'array_var'), NULL, 0));
         $this->assertProxyCode('return phpversion("apc");', 'apc_version', array());
     }
 


### PR DESCRIPTION
resolves an issue when apc_store or apc_add is called and $key is supplied an array and $var is null as expected.
$var is not used when $key is supplied as an array only check string type of key