### PR TITLE
FastCGI/Config: attempt to glob for sockets if no parameters supplied

### DIFF
--- a/src/CacheTool/Adapter/FastCGI.php
+++ b/src/CacheTool/Adapter/FastCGI.php
@@ -34,8 +34,9 @@ class FastCGI extends AbstractAdapter
     {
         // try to guess where it is
         if ($host === null) {
-            if (file_exists('/var/run/php5-fpm.sock')) {
-                $host = '/var/run/php5-fpm.sock';
+            $socket = current(glob('/var/run/php*.sock'));
+            if (!empty($socket)) {
+                $host = $socket;
             } else {
                 $host = '127.0.0.1:9000';
             }

--- a/src/CacheTool/Console/Config.php
+++ b/src/CacheTool/Console/Config.php
@@ -15,7 +15,7 @@ class Config implements \ArrayAccess
 {
     private $config = array(
         'adapter' => 'fastcgi',
-        'fastcgi' => '127.0.0.1:9000',
+        'fastcgi' => null,
         'temp_dir' => null
     );
 

--- a/tests/CacheTool/Console/ConfigTest.php
+++ b/tests/CacheTool/Console/ConfigTest.php
@@ -9,9 +9,9 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config = new Config();
 
         $this->assertTrue(isset($config['adapter']));
-        $this->assertTrue(isset($config['fastcgi']));
+        $this->assertFalse(isset($config['fastcgi']));
         $this->assertSame('fastcgi', $config['adapter']);
-        $this->assertSame('127.0.0.1:9000', $config['fastcgi']);
+        $this->assertNull($config['fastcgi']);
     }
 
     public function testSet()


### PR DESCRIPTION
This covers #17
It alters the current behaviour, though (might be seen as a BC). 

For simplicity, I've altered the logic in following way: if user didn't specify `--fcgi` option - cachetool shall try to find unix socket first, and in case no socket is found - it shall fallback to TCP.
Perhaps this behaviour should be documented?
