### PR TITLE
Use cachetool.yml config when empty fcgi option passed

### DIFF
--- a/src/CacheTool/Console/Application.php
+++ b/src/CacheTool/Console/Application.php
@@ -146,7 +146,9 @@ class Application extends BaseApplication
             $this->config['adapter'] = 'cli';
         } elseif ($input->hasParameterOption('--fcgi')) {
             $this->config['adapter'] = 'fastcgi';
-            $this->config['fastcgi'] = $input->getParameterOption('--fcgi');
+            if (!is_null($input->getParameterOption('--fcgi'))) {
+                $this->config['fastcgi'] = $input->getParameterOption('--fcgi');
+            }
         }
 
         if ($input->hasParameterOption('--tmp-dir') || $input->hasParameterOption('-t')) {


### PR DESCRIPTION
Currently console command does not make use of `cachetool.yml` configuration, when `--fcgi` option passed as empty.

```sh
cachetool opcache:status --fcgi
```

This PR will make use of `cachetool.yml` configuration, if `--fcgi` option value is not present.