### PR TITLE
Making cachetool compatible w/ php7

### DIFF
--- a/src/CacheTool/Adapter/FastCGI.php
+++ b/src/CacheTool/Adapter/FastCGI.php
@@ -21,9 +21,12 @@ class FastCGI extends AbstractAdapter
      */
     protected $client;
 
+    /**
+     * @var Array of patterns matching php socket files
+     */
     protected $possibleSocketFiles = [
-        '/var/run/php5-fpm.sock',
-        '/var/run/php/php7.0-fpm.sock'
+        '/var/run/php*.sock',
+        '/var/run/php/*.sock'
     ];
 
     /**

--- a/src/CacheTool/Adapter/FastCGI.php
+++ b/src/CacheTool/Adapter/FastCGI.php
@@ -24,7 +24,7 @@ class FastCGI extends AbstractAdapter
     /**
      * @var Array of patterns matching php socket files
      */
-    protected $possibleSocketFiles = [
+    protected $possibleSocketFilePatterns = [
         '/var/run/php*.sock',
         '/var/run/php/*.sock'
     ];
@@ -42,7 +42,8 @@ class FastCGI extends AbstractAdapter
     {
         // try to guess where it is
         if ($host === null) {
-            foreach ($this->possibleSocketFiles as $possibleSocketFile) {
+            foreach ($this->possibleSocketFilePatterns as $possibleSocketFilePattern) {
+                $possibleSocketFile = current(glob($possibleSocketFilePattern));
                 if (file_exists($possibleSocketFile)) {
                     $host = $possibleSocketFile;
                     break;

--- a/src/CacheTool/Adapter/FastCGI.php
+++ b/src/CacheTool/Adapter/FastCGI.php
@@ -21,6 +21,11 @@ class FastCGI extends AbstractAdapter
      */
     protected $client;
 
+    protected $possibleSocketFiles = [
+        '/var/run/php5-fpm.sock',
+        '/var/run/php/php7.0-fpm.sock'
+    ];
+
     /**
      * @var string
      */
@@ -34,9 +39,13 @@ class FastCGI extends AbstractAdapter
     {
         // try to guess where it is
         if ($host === null) {
-            if (file_exists('/var/run/php5-fpm.sock')) {
-                $host = '/var/run/php5-fpm.sock';
-            } else {
+            foreach ($this->possibleSocketFiles as $possibleSocketFile) {
+                if (file_exists($possibleSocketFile)) {
+                    $host = $possibleSocketFile;
+                    break;
+                }
+            }
+            if ($host === null) {
                 $host = '127.0.0.1:9000';
             }
         }

--- a/src/CacheTool/Command/ApcCacheInfoCommand.php
+++ b/src/CacheTool/Command/ApcCacheInfoCommand.php
@@ -54,8 +54,8 @@ class ApcCacheInfoCommand extends AbstractCommand
     {
         $this->ensureExtensionLoaded('apc');
 
-        $user = $this->getCacheTool()->apc_cache_info('user');
-        $system = $this->getCacheTool()->apc_cache_info('system');
+        $user = $this->getCacheTool()->apc_cache_info('user') ?: [];
+        $system = $this->getCacheTool()->apc_cache_info('system') ?: [];
 
         $this->normalize($user);
         $this->normalize($system);

--- a/src/CacheTool/Command/ApcCacheInfoFileCommand.php
+++ b/src/CacheTool/Command/ApcCacheInfoFileCommand.php
@@ -36,7 +36,7 @@ class ApcCacheInfoFileCommand extends ApcCacheInfoCommand
     {
         $this->ensureExtensionLoaded('apc');
 
-        $info = $this->getCacheTool()->apc_cache_info('system');
+        $info = $this->getCacheTool()->apc_cache_info('system') ?: [];
         $this->normalize($info);
 
         if (!$info) {

--- a/tests/CacheTool/Command/ApcBinDumpCommandTest.php
+++ b/tests/CacheTool/Command/ApcBinDumpCommandTest.php
@@ -6,6 +6,9 @@ class ApcBinDumpCommandTest extends CommandTest
 {
     public function testCommand()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
         $this->assertNoHHVM();
 
@@ -18,6 +21,9 @@ class ApcBinDumpCommandTest extends CommandTest
 
     public function testCommandWithFile()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
         $this->assertNoHHVM();
 

--- a/tests/CacheTool/Command/ApcBinDumpCommandTest.php
+++ b/tests/CacheTool/Command/ApcBinDumpCommandTest.php
@@ -6,7 +6,7 @@ class ApcBinDumpCommandTest extends CommandTest
 {
     public function testCommand()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();
@@ -21,7 +21,7 @@ class ApcBinDumpCommandTest extends CommandTest
 
     public function testCommandWithFile()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();

--- a/tests/CacheTool/Command/ApcBinLoadCommandTest.php
+++ b/tests/CacheTool/Command/ApcBinLoadCommandTest.php
@@ -6,7 +6,7 @@ class ApcBinLoadCommandTest extends CommandTest
 {
     public function testCommand()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();

--- a/tests/CacheTool/Command/ApcBinLoadCommandTest.php
+++ b/tests/CacheTool/Command/ApcBinLoadCommandTest.php
@@ -6,6 +6,9 @@ class ApcBinLoadCommandTest extends CommandTest
 {
     public function testCommand()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
         $this->assertNoHHVM();
 

--- a/tests/CacheTool/Command/ApcCacheClearCommandTest.php
+++ b/tests/CacheTool/Command/ApcCacheClearCommandTest.php
@@ -6,7 +6,7 @@ class ApcCacheClearCommandTest extends CommandTest
 {
     public function testCommand()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();
@@ -19,7 +19,7 @@ class ApcCacheClearCommandTest extends CommandTest
 
     public function testCommandUser()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();
@@ -31,7 +31,7 @@ class ApcCacheClearCommandTest extends CommandTest
 
     public function testException()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();

--- a/tests/CacheTool/Command/ApcCacheClearCommandTest.php
+++ b/tests/CacheTool/Command/ApcCacheClearCommandTest.php
@@ -6,6 +6,9 @@ class ApcCacheClearCommandTest extends CommandTest
 {
     public function testCommand()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
 
         $result = $this->runCommand('apc:cache:clear all -v');
@@ -16,6 +19,9 @@ class ApcCacheClearCommandTest extends CommandTest
 
     public function testCommandUser()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
 
         $result = $this->runCommand('apc:cache:clear user -v');
@@ -25,6 +31,9 @@ class ApcCacheClearCommandTest extends CommandTest
 
     public function testException()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
 
         $result = $this->runCommand('apc:cache:clear err -v');

--- a/tests/CacheTool/Command/ApcCacheInfoCommandTest.php
+++ b/tests/CacheTool/Command/ApcCacheInfoCommandTest.php
@@ -6,6 +6,9 @@ class ApcCacheInfoCommandTest extends CommandTest
 {
     public function testCommand()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
 
         $result = $this->runCommand('apc:cache:info');

--- a/tests/CacheTool/Command/ApcCacheInfoCommandTest.php
+++ b/tests/CacheTool/Command/ApcCacheInfoCommandTest.php
@@ -6,7 +6,7 @@ class ApcCacheInfoCommandTest extends CommandTest
 {
     public function testCommand()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();

--- a/tests/CacheTool/Command/ApcCacheInfoFileCommandTest.php
+++ b/tests/CacheTool/Command/ApcCacheInfoFileCommandTest.php
@@ -6,7 +6,7 @@ class ApcCacheInfoFileCommandTest extends CommandTest
 {
     public function testCommand()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();

--- a/tests/CacheTool/Command/ApcCacheInfoFileCommandTest.php
+++ b/tests/CacheTool/Command/ApcCacheInfoFileCommandTest.php
@@ -6,6 +6,9 @@ class ApcCacheInfoFileCommandTest extends CommandTest
 {
     public function testCommand()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
 
         $result = $this->runCommand('apc:cache:info:file -v');

--- a/tests/CacheTool/Command/ApcKeyDeleteCommandTest.php
+++ b/tests/CacheTool/Command/ApcKeyDeleteCommandTest.php
@@ -6,7 +6,7 @@ class ApcKeyDeleteCommandTest extends CommandTest
 {
     public function testCommand()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();

--- a/tests/CacheTool/Command/ApcKeyDeleteCommandTest.php
+++ b/tests/CacheTool/Command/ApcKeyDeleteCommandTest.php
@@ -6,6 +6,9 @@ class ApcKeyDeleteCommandTest extends CommandTest
 {
     public function testCommand()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
 
         $result = $this->runCommand('apc:key:delete key -v');

--- a/tests/CacheTool/Command/ApcKeyExistsCommandTest.php
+++ b/tests/CacheTool/Command/ApcKeyExistsCommandTest.php
@@ -6,7 +6,7 @@ class ApcKeyExistsCommandTest extends CommandTest
 {
     public function testCommand()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();

--- a/tests/CacheTool/Command/ApcKeyExistsCommandTest.php
+++ b/tests/CacheTool/Command/ApcKeyExistsCommandTest.php
@@ -6,6 +6,9 @@ class ApcKeyExistsCommandTest extends CommandTest
 {
     public function testCommand()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
 
         $result = $this->runCommand('apc:key:exists key -v');

--- a/tests/CacheTool/Command/ApcKeyFetchCommandTest.php
+++ b/tests/CacheTool/Command/ApcKeyFetchCommandTest.php
@@ -6,7 +6,7 @@ class ApcKeyFetchCommandTest extends CommandTest
 {
     public function testCommand()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();

--- a/tests/CacheTool/Command/ApcKeyFetchCommandTest.php
+++ b/tests/CacheTool/Command/ApcKeyFetchCommandTest.php
@@ -6,6 +6,9 @@ class ApcKeyFetchCommandTest extends CommandTest
 {
     public function testCommand()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
 
         $result = $this->runCommand('apc:key:fetch key -v');

--- a/tests/CacheTool/Command/ApcKeyStoreCommandTest.php
+++ b/tests/CacheTool/Command/ApcKeyStoreCommandTest.php
@@ -6,7 +6,7 @@ class ApcKeyStoreCommandTest extends CommandTest
 {
     public function testCommand()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();

--- a/tests/CacheTool/Command/ApcKeyStoreCommandTest.php
+++ b/tests/CacheTool/Command/ApcKeyStoreCommandTest.php
@@ -6,6 +6,9 @@ class ApcKeyStoreCommandTest extends CommandTest
 {
     public function testCommand()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
 
         $result = $this->runCommand('apc:key:store key value 3600 -v');

--- a/tests/CacheTool/Command/ApcSmaInfoCommandTest.php
+++ b/tests/CacheTool/Command/ApcSmaInfoCommandTest.php
@@ -6,6 +6,9 @@ class ApcSmaInfoCommandTest extends CommandTest
 {
     public function testCommand()
     {
+        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+            $this->markTestSkipped('Skip APC test w/ php7');
+        }
         $this->assertHasApc();
 
         $result = $this->runCommand('apc:sma:info -v');

--- a/tests/CacheTool/Command/ApcSmaInfoCommandTest.php
+++ b/tests/CacheTool/Command/ApcSmaInfoCommandTest.php
@@ -6,7 +6,7 @@ class ApcSmaInfoCommandTest extends CommandTest
 {
     public function testCommand()
     {
-        if (explode('.', PHP_VERSION_ID)[0] >= 7) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Skip APC test w/ php7');
         }
         $this->assertHasApc();


### PR DESCRIPTION
  * Add support of php7.0-fpm socket
  * Fix some php7 warn
  * Skip unit tests related to APC (not supported by php7)