### PR TITLE
Added APCIterator logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 cachetool.phar
 vendor
+.idea

--- a/src/CacheTool/Command/ApcuRegexpDeleteCommand.php
+++ b/src/CacheTool/Command/ApcuRegexpDeleteCommand.php
@@ -11,7 +11,6 @@
 
 namespace CacheTool\Command;
 
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -39,33 +38,14 @@ class ApcuRegexpDeleteCommand extends AbstractCommand
 
         $regexp = $input->getArgument('regexp');
 
-        $user = $this->getCacheTool()->apcu_cache_info('user');
+        $success = $this->getCacheTool()->apcu_regexp_delete($regexp);
 
-        $keys = array();
-        foreach ($user['cache_list'] as $key) {
-            $string = $key['info'];
-            if (preg_match('|' . $regexp . '|', $string)) {
-                $keys[] = $key;
-            }
-        }
-        $cpt = 0;
-        $table = new Table($output);
-        $table->setHeaders(array('Key', 'TTL', ));
-        $table->setRows($keys);
-        $table->render($output);
-        foreach ($keys as $key) {
-            $success = $this->getCacheTool()->apcu_delete($key['info']);
-            if ($output->isVerbose()) {
-                if ($success) {
-                    $output->writeln("<comment>APCu key <info>{$key['info']}</info> was deleted</comment>");
-                } else {
-                    $output->writeln("<comment>APCu key <info>{$key['info']}</info> could not be deleted.</comment>");
-                }
-            }
-            $cpt ++;
-        }
         if ($output->isVerbose()) {
-            $output->writeln("<comment>APCu key <info>{$cpt}</info> keys treated.</comment>");
+            if ($success) {
+                $output->writeln("<comment>APC keys by regexp <info>{$regexp}</info> was deleted</comment>");
+            } else {
+                $output->writeln("<comment>APC keys by regexp <info>{$regexp}</info> could not be deleted.</comment>");
+            }
         }
         return 1;
     }

--- a/src/CacheTool/Proxy/ApcuProxy.php
+++ b/src/CacheTool/Proxy/ApcuProxy.php
@@ -29,16 +29,17 @@ class ApcuProxy implements ProxyInterface
         return array(
             'apcu_add',
             'apcu_cache_info',
+            'apcu_regexp_get_keys',
             'apcu_cas',
             'apcu_clear_cache',
             'apcu_dec',
             'apcu_delete',
+            'apcu_regexp_delete',
             'apcu_exists',
             'apcu_fetch',
             'apcu_inc',
             'apcu_sma_info',
             'apcu_store',
-
             'apcu_version'
         );
     }
@@ -130,6 +131,40 @@ class ApcuProxy implements ProxyInterface
     }
 
     /**
+     * Retrieves caches keys & TTL from APCu's data store
+     *
+     * @since  3.1.1
+     *
+     * @param  null|string $regexp If is regex the return contains keys & ttl of entries found by regex, otherwise -
+     *                             keys & ttl of all entries
+     *
+     * @return boolean|array       Array of cached data's keys and ttl or FALSE on failure
+     */
+    public function apcu_regexp_get_keys($regexp = null)
+    {
+        if ($regexp && !preg_match("/^\/.+\/[a-z]*$/i", $regexp)) {
+            throw new \RuntimeException("{$regexp} is not a valid Regex");
+        }
+        $code = new Code();
+        $code->addStatement(sprintf(
+            '$keys = new \APCIterator("user", %s, APC_ITER_ALL, 10);',
+            var_export($regexp, true)
+        ));
+        $code->addStatement('$result = [];');
+        $code->addStatement('
+          if ($keys->getTotalCount()){
+            foreach ($keys as $key){
+              $result[] = [
+              "key" => $key["key"],
+              "ttl" => $key["ttl"]
+              ];
+            }
+          }');
+        $code->addStatement('return $result;');
+        return $this->adapter->run($code);
+    }
+
+    /**
      * Clears the user/system cache
      *
      * @since  2.0.0
@@ -187,6 +222,31 @@ class ApcuProxy implements ProxyInterface
             var_export($key, true)
         ));
 
+        return $this->adapter->run($code);
+    }
+
+    /**
+     * Retrieves caches keys & TTL from APCu's data store
+     *
+     * @since  3.1.1
+     *
+     * @param  null|string $regexp If is regex removes caches with keys found by regex,
+     *                             otherwise - removes all entries
+     *
+     * @return boolean    Return result
+     */
+    public function apcu_regexp_delete($regexp = null)
+    {
+        if ($regexp && !preg_match("/^\/.+\/[a-z]*$/i", $regexp)) {
+            throw new \RuntimeException("{$regexp} is not a valid Regex");
+        }
+
+        $code = new Code();
+        $code->addStatement(sprintf(
+            '$keys = new \APCIterator("user", %s, APC_ITER_KEY, 10);',
+            var_export($regexp, true)
+        ));
+        $code->addStatement('return apc_delete($keys);');
         return $this->adapter->run($code);
     }
 

--- a/tests/CacheTool/Proxy/ApcuProxyTest.php
+++ b/tests/CacheTool/Proxy/ApcuProxyTest.php
@@ -6,7 +6,7 @@ class ApcuProxyTest extends ProxyTest
 {
     public function testGetFunctions()
     {
-        $this->assertCount(12, $this->createProxyInstance()->getFunctions());
+        $this->assertCount(14, $this->createProxyInstance()->getFunctions());
     }
 
     /**


### PR DESCRIPTION
I refactored apcu:regexp:delete command to use APCIterator instead of loading whole apc_cache_info due to high memory consumption and poor performance on large cache stores.
This is part of possible solution of my question #51 