### PR TITLE
Add support for symfony4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "keywords": ["cache", "opcache", "apc", "fastcgi", "opcode", "fpm"],
     "require": {
         "php": ">=5.5.9",
-        "symfony/console": "~3.0",
-        "symfony/dependency-injection": "~3.0",
-        "symfony/process": "~3.0",
-        "symfony/yaml": "~3.0",
+        "symfony/console": "~3.0|~4.0",
+        "symfony/dependency-injection": "~3.0|~4.0",
+        "symfony/process": "~3.0|~4.0",
+        "symfony/yaml": "~3.0|~4.0",
         "psr/log": "~1.0",
         "monolog/monolog": "~1.1",
         "adoy/fastcgi-client": "~1.0"


### PR DESCRIPTION
This change will allow to install CacheTool alongside with symfony4 and symfony3 - not only with symfony3.