### PR TITLE
Allow configuration file to specify which commands are available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ fastcgi: /var/run/php5-fpm.sock
 temp_dir: /dev/shm/cachetool
 ```
 
+You can define the supported extensions in the config file. By default, `apc`, `apcu`, and
+`opcache` are enabled. To disable `apc`, add this to your config file:
+
+```yml
+extensions: [apcu, opcache]
+```
+
 Usage (as a library)
 --------------------
 

--- a/src/CacheTool/Console/Application.php
+++ b/src/CacheTool/Console/Application.php
@@ -61,33 +61,39 @@ class Application extends BaseApplication
         $commands = parent::getDefaultCommands();
         $commands[] = new CacheToolCommand\SelfUpdateCommand();
 
-        $commands[] = new CacheToolCommand\ApcBinDumpCommand();
-        $commands[] = new CacheToolCommand\ApcBinLoadCommand();
-        $commands[] = new CacheToolCommand\ApcCacheClearCommand();
-        $commands[] = new CacheToolCommand\ApcCacheInfoCommand();
-        $commands[] = new CacheToolCommand\ApcCacheInfoFileCommand();
-        $commands[] = new CacheToolCommand\ApcKeyDeleteCommand();
-        $commands[] = new CacheToolCommand\ApcKeyExistsCommand();
-        $commands[] = new CacheToolCommand\ApcKeyFetchCommand();
-        $commands[] = new CacheToolCommand\ApcKeyStoreCommand();
-        $commands[] = new CacheToolCommand\ApcSmaInfoCommand();
-        $commands[] = new CacheToolCommand\ApcRegexpDeleteCommand();
+        if (in_array('apc', $this->config['extensions'], true)) {
+            $commands[] = new CacheToolCommand\ApcBinDumpCommand();
+            $commands[] = new CacheToolCommand\ApcBinLoadCommand();
+            $commands[] = new CacheToolCommand\ApcCacheClearCommand();
+            $commands[] = new CacheToolCommand\ApcCacheInfoCommand();
+            $commands[] = new CacheToolCommand\ApcCacheInfoFileCommand();
+            $commands[] = new CacheToolCommand\ApcKeyDeleteCommand();
+            $commands[] = new CacheToolCommand\ApcKeyExistsCommand();
+            $commands[] = new CacheToolCommand\ApcKeyFetchCommand();
+            $commands[] = new CacheToolCommand\ApcKeyStoreCommand();
+            $commands[] = new CacheToolCommand\ApcSmaInfoCommand();
+            $commands[] = new CacheToolCommand\ApcRegexpDeleteCommand();
+        }
 
-        $commands[] = new CacheToolCommand\ApcuCacheClearCommand();
-        $commands[] = new CacheToolCommand\ApcuCacheInfoCommand();
-        $commands[] = new CacheToolCommand\ApcuCacheInfoKeysCommand();
-        $commands[] = new CacheToolCommand\ApcuKeyDeleteCommand();
-        $commands[] = new CacheToolCommand\ApcuKeyExistsCommand();
-        $commands[] = new CacheToolCommand\ApcuKeyFetchCommand();
-        $commands[] = new CacheToolCommand\ApcuKeyStoreCommand();
-        $commands[] = new CacheToolCommand\ApcuSmaInfoCommand();
-        $commands[] = new CacheToolCommand\ApcuRegexpDeleteCommand();
+        if (in_array('apcu', $this->config['extensions'], true)) {
+            $commands[] = new CacheToolCommand\ApcuCacheClearCommand();
+            $commands[] = new CacheToolCommand\ApcuCacheInfoCommand();
+            $commands[] = new CacheToolCommand\ApcuCacheInfoKeysCommand();
+            $commands[] = new CacheToolCommand\ApcuKeyDeleteCommand();
+            $commands[] = new CacheToolCommand\ApcuKeyExistsCommand();
+            $commands[] = new CacheToolCommand\ApcuKeyFetchCommand();
+            $commands[] = new CacheToolCommand\ApcuKeyStoreCommand();
+            $commands[] = new CacheToolCommand\ApcuSmaInfoCommand();
+            $commands[] = new CacheToolCommand\ApcuRegexpDeleteCommand();
+        }
 
-        $commands[] = new CacheToolCommand\OpcacheConfigurationCommand();
-        $commands[] = new CacheToolCommand\OpcacheResetCommand();
-        $commands[] = new CacheToolCommand\OpcacheStatusCommand();
-        $commands[] = new CacheToolCommand\OpcacheStatusScriptsCommand();
-        $commands[] = new CacheToolCommand\OpcacheInvalidateScriptsCommand();
+        if (in_array('opcache', $this->config['extensions'], true)) {
+            $commands[] = new CacheToolCommand\OpcacheConfigurationCommand();
+            $commands[] = new CacheToolCommand\OpcacheResetCommand();
+            $commands[] = new CacheToolCommand\OpcacheStatusCommand();
+            $commands[] = new CacheToolCommand\OpcacheStatusScriptsCommand();
+            $commands[] = new CacheToolCommand\OpcacheInvalidateScriptsCommand();
+        }
 
         $commands[] = new CacheToolCommand\StatCacheClearCommand();
         $commands[] = new CacheToolCommand\StatRealpathGetCommand();

--- a/src/CacheTool/Console/Config.php
+++ b/src/CacheTool/Console/Config.php
@@ -17,6 +17,7 @@ class Config implements \ArrayAccess
 {
     private $config = array(
         'adapter' => 'fastcgi',
+        'extensions' => ['apc', 'apcu', 'opcache'],
         'fastcgi' => null,
         'temp_dir' => null
     );

--- a/src/CacheTool/Console/Config.php
+++ b/src/CacheTool/Console/Config.php
@@ -25,7 +25,7 @@ class Config implements \ArrayAccess
     public function __construct(array $config = array())
     {
         if (!empty($config)) {
-            $this->config = $config;
+            $this->config = array_replace($this->config, $config);
 
             if (!isset($this->config['temp_dir'])) {
                 $this->config['temp_dir'] = sys_get_temp_dir();

--- a/tests/CacheTool/Console/ApplicationTest.php
+++ b/tests/CacheTool/Console/ApplicationTest.php
@@ -59,4 +59,36 @@ class ApplicationTest extends CommandTest
 
         $this->assertSame(42, $code);
     }
+
+    public function testNoSupportedExtensions()
+    {
+        $app = new Application(new Config(array('extensions' => [])));
+        $app->setAutoExit(false);
+
+        $output = new BufferedOutput();
+        $code = $app->run(new StringInput("list"), $output);
+        $content = $output->fetch();
+
+        $this->assertSame(0, $code);
+        $this->assertContains('stat:clear', $content);
+        $this->assertNotContains('apc:bin:dump', $content);
+        $this->assertNotContains('apcu:cache:clear', $content);
+        $this->assertNotContains('opcache:configuration', $content);
+    }
+
+    public function testAllSupportedExtensions()
+    {
+        $app = new Application(new Config(array('extensions' => ['apc', 'apcu', 'opcache'])));
+        $app->setAutoExit(false);
+
+        $output = new BufferedOutput();
+        $code = $app->run(new StringInput("list"), $output);
+        $content = $output->fetch();
+
+        $this->assertSame(0, $code);
+        $this->assertContains('stat:clear', $content);
+        $this->assertContains('apc:bin:dump', $content);
+        $this->assertContains('apcu:cache:clear', $content);
+        $this->assertContains('opcache:configuration', $content);
+    }
 }


### PR DESCRIPTION
Many users will not have `apc` and `apcu` enabled on the same servers. Symfony Console's `\Symfony\Component\Console\Application::find` method will attempt to find commands that match partial names but this cannot work when there are commands whose namespaces are subsets of other commands.

For example, when all extensions are enabled, it's not possible to abbreviate most of the commands in either `apc` or `apcu` namespace:

```
$ ./bin/cachetool a:k:f some-key --no-ansi
                                                       
  Command "a:k:f" is ambiguous.                        
  Did you mean one of these?                           
      apc:key:fetch  Shows the content of an APC key   
      apcu:key:fetch Shows the content of an APCu key  
                                                       
```

When the config file specifies which extensions to support, calling commands with abbreviations is possible:

```yaml
extensions: [opcache, apcu]
```

```
$ ./bin/cachetool a:k:f some-key
APCu key=some-key has value='thing'
```

To avoid breaking backward compatibility, `\CacheTool\Console\Config::__construct` now uses `array_replace` to provide defaults when config properties aren't set in the `$config` argument.