### PR TITLE
Exclude from NewRelic monitoring

### DIFF
--- a/src/CacheTool/Code.php
+++ b/src/CacheTool/Code.php
@@ -70,6 +70,10 @@ class Code
     public function getCodeExecutable()
     {
         $template =<<<'EOF'
+if (extension_loaded('newrelic')) {
+    newrelic_ignore_transaction();
+}
+
 $errors = array();
 
 $cachetool_error_handler_%s = function($errno, $errstr, $errfile, $errline) use (&$errors) {


### PR DESCRIPTION
I use cachetool to reset the php-fpm opcache after each deployment. The tool executes a lot of very small php scripts.
We are using NewRelic APM to monitor our PHP application and we can see the effect of this operation on the dashboard. 
![image](https://user-images.githubusercontent.com/400034/45921181-27249d80-beb1-11e8-920f-4cc841aa2490.png)

https://docs.newrelic.com/docs/agents/php-agent/php-agent-api/newrelic_ignore_transaction