### PR TITLE
Fix command line opcache:compile command

### DIFF
--- a/src/CacheTool/Console/Application.php
+++ b/src/CacheTool/Console/Application.php
@@ -93,7 +93,7 @@ class Application extends BaseApplication
             $commands[] = new CacheToolCommand\OpcacheStatusCommand();
             $commands[] = new CacheToolCommand\OpcacheStatusScriptsCommand();
             $commands[] = new CacheToolCommand\OpcacheInvalidateScriptsCommand();
-            $commands[] = new CacheToolCommand\OpcacheInvalidateScriptsCommand();
+            $commands[] = new CacheToolCommand\OpcacheCompileScriptsCommand();
         }
 
         $commands[] = new CacheToolCommand\StatCacheClearCommand();


### PR DESCRIPTION
Looked at the original PR, this must have been a little copy/paste error.