### PR TITLE
Fixed missing registration of OpcacheCompileScriptsCommand

### DIFF
--- a/src/CacheTool/Console/Application.php
+++ b/src/CacheTool/Console/Application.php
@@ -93,7 +93,7 @@ class Application extends BaseApplication
             $commands[] = new CacheToolCommand\OpcacheStatusCommand();
             $commands[] = new CacheToolCommand\OpcacheStatusScriptsCommand();
             $commands[] = new CacheToolCommand\OpcacheInvalidateScriptsCommand();
-            $commands[] = new CacheToolCommand\OpcacheInvalidateScriptsCommand();
+            $commands[] = new CacheToolCommand\OpcacheCompileScriptsCommand();
         }
 
         $commands[] = new CacheToolCommand\StatCacheClearCommand();


### PR DESCRIPTION
Fixes #93

Copy / paste error in the original implementation meaning it doesn't get registered at all.