### PR TITLE
Moved to psr-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
         }
     ],
     "autoload": {
-        "psr-0": { "CacheTool": "src/" }
+        "psr-4": { "CacheTool\\": "src/CacheTool/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "CacheTool\\": "tests/CacheTool/" }
     },
     "repositories": [
         {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="CacheTool Test Suite">
             <directory>tests/CacheTool/</directory>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,0 @@
-<?php
-
-$loader = require __DIR__ . "/../vendor/autoload.php";
-$loader->addPsr4('CacheTool\\', __DIR__.'/CacheTool');


### PR DESCRIPTION
- PSR-0 has been marked as deprecated. PSR-4 is now recommended as an alternative. https://www.php-fig.org/psr/psr-0/
- Added autoload-dev to define autoload rules for development purposes. see https://getcomposer.org/doc/04-schema.md#autoload-dev