### PR TITLE
Add opcache:compile:script command to compile a single file

### DIFF
--- a/src/CacheTool/Command/OpcacheCompileScriptCommand.php
+++ b/src/CacheTool/Command/OpcacheCompileScriptCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of CacheTool.
+ *
+ * (c) Samuel Gordalina <samuel.gordalina@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CacheTool\Command;
+
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class OpcacheCompileScriptCommand extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('opcache:compile:script')
+            ->setDescription('Compile a given script to the opcode cache')
+            ->addArgument('path', InputArgument::REQUIRED)
+            ->setHelp('');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->ensureExtensionLoaded('Zend OPcache');
+        $path = $input->getArgument('path');
+
+        $info = $this->getCacheTool()->opcache_get_status(true);
+
+        if ($info === false) {
+            throw new \RuntimeException('opcache_get_status(): No Opcache status info available.  Perhaps Opcache is disabled via opcache.enable or opcache.enable_cli?');
+        }
+
+        $splFiles = array($path);
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(array(
+                'Compiled',
+                'Filename'
+            ))
+            ->setRows($this->processFilelist($splFiles))
+        ;
+
+        $table->render();
+    }
+
+    protected function processFileList($splFiles)
+    {
+        $list = array();
+
+        foreach ($splFiles as $file) {
+            $list[] = array(
+                $this->getCacheTool()->opcache_compile_file(realpath($file)),
+                realpath($file)
+            );
+        }
+
+        return $list;
+    }
+
+}

--- a/src/CacheTool/Console/Application.php
+++ b/src/CacheTool/Console/Application.php
@@ -93,7 +93,8 @@ class Application extends BaseApplication
             $commands[] = new CacheToolCommand\OpcacheStatusCommand();
             $commands[] = new CacheToolCommand\OpcacheStatusScriptsCommand();
             $commands[] = new CacheToolCommand\OpcacheInvalidateScriptsCommand();
-            $commands[] = new CacheToolCommand\OpcacheInvalidateScriptsCommand();
+            $commands[] = new CacheToolCommand\OpcacheCompileScriptsCommand();
+            $commands[] = new CacheToolCommand\OpcacheCompileScriptCommand();
         }
 
         $commands[] = new CacheToolCommand\StatCacheClearCommand();


### PR DESCRIPTION
This PR adds new command - opcache:compile:script which compiles a single file given as `path` argument.
This is useful when you don't necessarily want to compile all files in the directory as it might be too memory consuming.