### PR TITLE
if PHP_BINARY constant exists use it as php-binary in cli-adapter

### DIFF
--- a/src/CacheTool/Adapter/Cli.php
+++ b/src/CacheTool/Adapter/Cli.php
@@ -24,7 +24,11 @@ class Cli extends AbstractAdapter
         $file = $this->createTemporaryFile();
         $code->writeTo($file);
 
-        $process = new Process("php $file");
+        $php = 'php';
+        if (defined('PHP_BINARY')) {
+            $php = PHP_BINARY;
+        }
+        $process = new Process("$php $file");
         $process->run();
 
         if (!@unlink($file)) {


### PR DESCRIPTION
On some systems it is not possible use the php-binary from path. Therefore it would be useful, to utilize the same php binary used to invoke the cachetool in the cli-adapters process. This PR makes it possible. It does not change the default behaviour, so if one uses the cachetool like …

`cachetool.phar --cli opcache:reset` (with cachetool.phar being executable)
`php cachetool.phar --cli opcache:reset` (with explicit php-binary)

… the same php-binary will be used, as without this PR.

In my case I run cachetool like …

`/opt/local/bin/php72 cachetool.phar --cli opcache:reset`

… and without this PR, it fails because there is a php-binary in PATH (/usr/bin/php),
which does not have the Opcache enabled. And actually it would be wrong to clear
the opcache in this binaries context.

I appreciate any Feedback on this …
Cheers,
Stephan 