### PR TITLE
Fail with informative error if explicit --tmp-dir isn't writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Support for APC cache has been removed.
 - Use PSR-4 autoloading.
 - Use `PHP_BINARY` in the CLI adapter to execute PHP.
+- Passing ``--tmp-dir`` a directory that is not writable now fails rather than
+  falling back to the default directories.
 
 # 4.0.0
 

--- a/src/CacheTool.php
+++ b/src/CacheTool.php
@@ -51,14 +51,16 @@ class CacheTool
     {
         $this->logger = $logger ?: new Logger('cachetool');
 
-        $tempDirs = array($tempDir, '/dev/shm', '/var/run', sys_get_temp_dir());
-
-        foreach ($tempDirs as $tempDir) {
-            if (is_dir($tempDir) && is_writable($tempDir)) {
-                $this->tempDir = $tempDir;
-                break;
+        if (is_null($tempDir)) {
+            $tempDirs = array('/dev/shm', '/var/run', sys_get_temp_dir());
+            foreach ($tempDirs as $dir) {
+                if (is_dir($dir) && is_writable($dir)) {
+                    $tempDir = $dir;
+                    break;
+                }
             }
         }
+        $this->tempDir = $tempDir;
     }
 
     /**
@@ -102,6 +104,11 @@ class CacheTool
     public function getAdapter()
     {
         return $this->adapter;
+    }
+
+    public function getTempDir()
+    {
+        return $this->tempDir;
     }
 
     /**

--- a/tests/CacheToolTest.php
+++ b/tests/CacheToolTest.php
@@ -42,6 +42,14 @@ class CacheToolTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($logger, $cachetool->getLogger());
     }
 
+    public function testFactoryWithTempDirNotWritable()
+    {
+        $adapter = new Adapter\FastCGI();
+        $tempDir = '/doesnotexit';
+        $cachetool = CacheTool::factory($adapter, $tempDir, $this->getLogger());
+        $this->assertSame($tempDir, $cachetool->getTempDir());
+    }
+
     public function testLoggerWithAdapter()
     {
         $cachetool = new CacheTool(null, $this->getLogger());

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -89,4 +89,36 @@ class ApplicationTest extends CommandTest
         $this->assertContains('apcu:cache:clear', $content);
         $this->assertContains('opcache:configuration', $content);
     }
+
+    public function testWithTmpDirArgNotWriable()
+    {
+        $app = new Application(new Config());
+        $app->setAutoExit(false);
+
+        $output = new BufferedOutput();
+        $code = $app->run(new StringInput('opcache:reset --tmp-dir=/doesnotexist'), $output);
+        $content = $output->fetch();
+
+        $this->assertSame(1, $code);
+        $this->assertRegExp(
+            '|Could not write to `/doesnotexist/cachetool-.*\.php`:|',
+            $content
+        );
+    }
+
+    public function testWithTmpDirConfigNotWriable()
+    {
+        $app = new Application(new Config(array('temp_dir' => '/doesnotexist')));
+        $app->setAutoExit(false);
+
+        $output = new BufferedOutput();
+        $code = $app->run(new StringInput('opcache:reset'), $output);
+        $content = $output->fetch();
+
+        $this->assertSame(1, $code);
+        $this->assertRegExp(
+            '|Could not write to `/doesnotexist/cachetool-.*\.php`:|',
+            $content
+        );
+    }
 }


### PR DESCRIPTION
Previously, if the passed --tmp-dir did not exist or was not writable,
cachetool would fallback to /dev/shm. As the user is explicitly passing
a directory, it is safe to assume that they want to use that directory
and only that directly. Falling back to some other directory is
undesired and counter intuitive. In my own case, it made debugging more
difficult as I had difficulty correlating directory permissions with
expected results.

Now assumes the passed --tmp-dir and if it is not writable, will fail
appropriately with a permission error or "No such file or directory"
error.