### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,14 @@
-env:
-  global:
-    secure: "NjbqUJv8rY5GeDdpX5Ygl58f2q+OKZqzzz1EuWdVxa3R/nMspKxFbWuM6L/pJsogzNrZBn6tAX0ke7Ojz6t/RNSe8XYrjis4lPEf9c/KN7/ESZg7fIkrJOegrY/CUYa0KjOqMSxouEcU/6maNjP3jI/4Bdxd7rSJPduriCSdCAI="
-
 language: php
 php:
-    - 7.1
-    - 7.2
-
-before_install:
-  - composer config --global github-oauth.github.com "$GITHUB_TOKEN"
+  - 7.1
+  - 7.2
 
 install:
-    - composer self-update
-    - composer install --prefer-source
-
-#before_script:
-    #- sudo apt-get install php5-fpm
+  - composer install
 
 script:
-    - phpunit --coverage-clover=coverage.clover
+  - $(composer config bin-dir)/phpunit --coverage-clover=coverage.clover
 
 after_script:
-    - wget https://scrutinizer-ci.com/ocular.phar
-    - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,5 @@
     "autoload": {
         "psr-0": { "CacheTool": "src/" }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/gordalina/cachetool"
-        }
-    ],
     "bin": ["bin/cachetool"]
 }


### PR DESCRIPTION
Remove composer self-update from .travis.yml

Unnecessary and is currently breaking Travis CI. Simply rely on the installed version instead. Drop --prefer-source. Fixes error:

```
[UnexpectedValueException]
Your github oauth token for github.com contains invalid characters: ""
```

---

Remove "repositories" section from composer.json

For details on repositories, see the composer docs:

https://getcomposer.org/doc/05-repositories.md#repositories

> A repository is a package source. It's a list of packages/versions. > Composer will look in all your repositories to find the packages your > project requires.

The cachetool git is not a package repository to be consumed by composer.

---

General cleanup of .travis.yml by removing unused sections and fixing indentation.
