### PR TITLE
Set opcache.enable_cli before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ php:
   - 7.2
   - 7.3
 
+before_install:
+  - echo 'opcache.enable_cli = 1' > $(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/cachetool.ini
+
 install:
   - composer install
 


### PR DESCRIPTION
Avoids skipping tests with the message:

    OPcache extension is not loaded.