### PR TITLE
Switch to using test INI file on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 7.3
 
 before_install:
-  - echo 'opcache.enable_cli = 1' > $(php -r 'echo PHP_CONFIG_FILE_SCAN_DIR;')/cachetool.ini
+  - phpenv config-add tests/cachetool.ini
 
 install:
   - composer install

--- a/tests/cachetool.ini
+++ b/tests/cachetool.ini
@@ -1,10 +1,9 @@
-extension=apc.so
 extension=apcu.so
 
 ; APC
 apc.enabled=1
-apc.cli_enabled=1
+apc.enable_cli=1
 
 ; OPcache
 opcache.enable=1
-opcache.cli_enabled=1
+opcache.enable_cli=1


### PR DESCRIPTION
Avoids skipping most tests. apc is no longer a supported module, so drop
it from the file. Correct option from "cli_enabled" to "enable_cli".