### PR TITLE
Test against PHP nightly version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - nightly
 
 before_install:
   - phpenv config-add tests/cachetool.ini


### PR DESCRIPTION
Helps ensure the package is compatible and ready to be used with the
next version of PHP.