### PR TITLE
Fix test testCodeExecutable

### DIFF
--- a/tests/CodeTest.php
+++ b/tests/CodeTest.php
@@ -69,7 +69,7 @@ class CodeTest extends \PHPUnit\Framework\TestCase
 
         ob_start();
         eval($exec);
-        return ob_get_clean();
+        $result = ob_get_clean();
 
         $this->assertTrue(strlen($result) > 0);
 


### PR DESCRIPTION
It previously returned early by mistake rather than using the and
verifying the results.