### PR TITLE
Start PHP-FPM process before running tests

### DIFF
--- a/tests/Adapter/FastCGITest.php
+++ b/tests/Adapter/FastCGITest.php
@@ -3,23 +3,21 @@
 namespace CacheTool\Adapter;
 
 use CacheTool\Code;
+use CacheTool\PhpFpmRunner;
 
 class FastCGITest extends \PHPUnit\Framework\TestCase
 {
     public function testRun()
     {
-        $fcgi = new FastCGI();
+        $fpm = new PhpFpmRunner();
+        $fcgi = new FastCGI($fpm->socket);
         $fcgi->setTempDir(sys_get_temp_dir());
         $fcgi->setLogger($this->getMockBuilder('Monolog\Logger')->disableOriginalConstructor()->getMock());
 
         $code = Code::fromString('return true;');
 
-        try {
-            $result = $fcgi->run($code);
-            $this->assertTrue($result);
-        } catch (\RuntimeException $e) {
-            $this->markTestSkipped($e->getMessage());
-        }
+        $result = $fcgi->run($code);
+        $this->assertTrue($result);
     }
 
     public function testGetScriptFileNameWithChroot()

--- a/tests/PhpFpmRunner.php
+++ b/tests/PhpFpmRunner.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace CacheTool;
+
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Process\Process;
+
+class PhpFpmRunner
+{
+    /**
+     * @var string
+     */
+    public $socket;
+
+    /**
+     * @var process
+     */
+    private $process;
+
+    public function __construct()
+    {
+        $process = new Process(['which', 'php-fpm']);
+        $status = $process->run();
+        if ($status) {
+            Assert::markTestSkipped('PHP-FPM is not available.');
+        }
+
+        $this->socket = tempnam(sys_get_temp_dir(), 'cachetool');
+        if (!$this->socket) {
+            throw new \RuntimeException('Could not create temporary file.');
+        }
+        unlink($this->socket);
+        $this->socket .= '.sock';
+
+        $this->process = new Process(
+            [
+                'php-fpm',
+                '--nodaemonize',
+                '--fpm-config',
+                __DIR__ . '/php-fpm.conf',
+            ],
+            null,
+            ['PHP_FPM_LISTEN' => $this->socket]
+        );
+        $this->process->start();
+
+        // Wait for socket to be ready.
+        while (!file_exists($this->socket));
+    }
+
+    public function __destruct()
+    {
+        $this->process->stop();
+    }
+}

--- a/tests/php-fpm.conf
+++ b/tests/php-fpm.conf
@@ -1,0 +1,7 @@
+[global]
+error_log = /dev/null
+
+[www]
+listen = ${PHP_FPM_LISTEN}
+pm = static
+pm.max_children = 1


### PR DESCRIPTION
Allows running tests with less system configuration.

    There was 1 skipped test:

    1) CacheTool\Adapter\FastCGITest::testRun
    FastCGI error: fsockopen(): unable to connect to 127.0.0.1:9000 (Connection refused) (127.0.0.1:9000)

    .../cachetool/tests/Adapter/FastCGITest.php:21