### PR TITLE
Remove unused test skip

### DIFF
--- a/tests/Adapter/FastCGITest.php
+++ b/tests/Adapter/FastCGITest.php
@@ -81,11 +81,7 @@ class FastCGITest extends \PHPUnit\Framework\TestCase
 
         $code = Code::fromString('return true;');
 
-        try {
-            $result = $fcgi->run($code);
-            $this->assertTrue($result);
-        } catch (\RuntimeException $e) {
-            $this->markTestSkipped($e->getMessage());
-        }
+        $result = $fcgi->run($code);
+        $this->assertTrue($result);
     }
 }

--- a/tests/Adapter/WebTest.php
+++ b/tests/Adapter/WebTest.php
@@ -19,12 +19,7 @@ class WebTest extends \PHPUnit\Framework\TestCase
 
         $code = Code::fromString('return true;');
 
-        try {
-            $result = $web->run($code);
-        } catch (\RuntimeException $e) {
-            $this->markTestSkipped($e->getMessage());
-        }
-
+        $result = $web->run($code);
         $this->assertTrue($result);
     }
 }


### PR DESCRIPTION
The test doesn't require PHP-FPM to pass. The test is never expected to
skip.