### PR TITLE
Remove false failure in the OpcacheProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Use `PHP_BINARY` in the CLI adapter to execute PHP.
 - Passing ``--tmp-dir`` a directory that is not writable now fails rather than
   falling back to the default directories.
+- Add workaround for `opcache_reset()` bug
+  <https://bugs.php.net/bug.php?id=71621>.
 
 # 4.0.0
 

--- a/src/Proxy/OpcacheProxy.php
+++ b/src/Proxy/OpcacheProxy.php
@@ -134,8 +134,11 @@ class OpcacheProxy implements ProxyInterface
      */
     public function opcache_reset()
     {
+        // Avoid using the opcache_reset() return value to workaround PHP bug
+        // https://bugs.php.net/bug.php?id=71621
         $code = new Code();
-        $code->addStatement('return opcache_reset();');
+        $code->addStatement('opcache_reset();');
+        $code->addStatement('return true;');
 
         return $this->adapter->run($code);
     }

--- a/tests/Proxy/OpcacheProxyTest.php
+++ b/tests/Proxy/OpcacheProxyTest.php
@@ -15,7 +15,7 @@ class OpcacheProxyTest extends ProxyTest
         $this->assertProxyCode("return opcache_get_configuration();", 'opcache_get_configuration', []);
         $this->assertProxyCode("return opcache_get_status(true);", 'opcache_get_status', [true]);
         $this->assertProxyCode("return opcache_invalidate('key', true);", 'opcache_invalidate', ['key', true]);
-        $this->assertProxyCode("return opcache_reset();", 'opcache_reset', []);
+        $this->assertProxyCode("opcache_reset();\nreturn true;", 'opcache_reset', []);
         $this->assertProxyCode('return phpversion("Zend OPcache");', 'opcache_version', []);
     }
 


### PR DESCRIPTION
Due to a upstream bug in PHP, opcache_reset() sometimes erroneously
returns false. This occurs most frequently when consecutive times
quickly. This can cause cachetool to exit with a non-zero exit status.
Tools that check this exit status could report a failure further. To
avoid this false failure, always return true once the extension has been
loaded.

For details on the bug, see:

https://bugs.php.net/bug.php?id=71621