### PR TITLE
Use fallback for empty PHP_BINARY constant in cli-adapter

### DIFF
--- a/src/Adapter/Cli.php
+++ b/src/Adapter/Cli.php
@@ -24,7 +24,7 @@ class Cli extends AbstractAdapter
         $file = $this->createTemporaryFile();
         $code->writeTo($file);
 
-        $process = new Process([PHP_BINARY, $file]);
+        $process = new Process([PHP_BINARY ?: "php", $file]);
         $process->run();
 
         if (!@unlink($file)) {

--- a/tests/Adapter/CliTest.php
+++ b/tests/Adapter/CliTest.php
@@ -43,7 +43,8 @@ class CliTest extends \PHPUnit\Framework\TestCase
         $result = $cli->run($code);
 
         if ('' === PHP_BINARY) {
-            $this->assertEquals('php', $result);
+            $this->assertNotEmpty($result);
+            $this->assertFileExists($result);
         } else {
             $this->assertEquals(PHP_BINARY, $result);
         }

--- a/tests/Adapter/CliTest.php
+++ b/tests/Adapter/CliTest.php
@@ -31,4 +31,21 @@ class CliTest extends \PHPUnit\Framework\TestCase
         $code = Code::fromString('throw new \Exception("test");');
         $result = $cli->run($code);
     }
+
+    public function testPhpBinary()
+    {
+        $cli = new Cli();
+        $cli->setTempDir(sys_get_temp_dir());
+        $cli->setLogger($this->getMockBuilder('Monolog\Logger')->disableOriginalConstructor()->getMock());
+
+        $code = Code::fromString('return PHP_BINARY;');
+
+        $result = $cli->run($code);
+
+        if ('' === PHP_BINARY) {
+            $this->assertEquals('php', $result);
+        } else {
+            $this->assertEquals(PHP_BINARY, $result);
+        }
+    }
 }

--- a/tests/Adapter/CliTest.php
+++ b/tests/Adapter/CliTest.php
@@ -46,7 +46,7 @@ class CliTest extends \PHPUnit\Framework\TestCase
             $this->assertNotEmpty($result);
             $this->assertFileExists($result);
         } else {
-            $this->assertEquals(PHP_BINARY, $result);
+            $this->assertSame(PHP_BINARY, $result);
         }
     }
 }


### PR DESCRIPTION
As already mentioned in [PR 101](https://github.com/gordalina/cachetool/pull/101#issuecomment-518533295)  the PHP_BINARY is always defined, but sometimes(*) it is just an empty string. Therefore I propose to not just rely on its value, but use the hardcoded string “php” if the PHP_BINARY is empty. This PR adds the proposed behaviour, plus a corresponding unit-test method.

*) Only the CLI-SAPI can give a reasonable value, all other SAPIs (FPM, mod_php, …) are not able to define the path to the binary, as it is out of their scope.