### PR TITLE
Prefer assertSame() over assertEquals()

### DIFF
--- a/tests/Adapter/FastCGITest.php
+++ b/tests/Adapter/FastCGITest.php
@@ -28,7 +28,7 @@ class FastCGITest extends \PHPUnit\Framework\TestCase
         $method = $class->getMethod('getScriptFileName');
         $method->setAccessible(true);
 
-        self::assertEquals('/test.php', $method->invoke($fcgi, "{$tmpdir}/test.php"));
+        $this->assertSame('/test.php', $method->invoke($fcgi, "{$tmpdir}/test.php"));
     }
 
     public function testGetScriptFileNameWithoutChroot()
@@ -38,7 +38,7 @@ class FastCGITest extends \PHPUnit\Framework\TestCase
         $method = $class->getMethod('getScriptFileName');
         $method->setAccessible(true);
 
-        self::assertEquals('/tmp/test.php', $method->invoke($fcgi, '/tmp/test.php'));
+        $this->assertSame('/tmp/test.php', $method->invoke($fcgi, '/tmp/test.php'));
     }
 
     public function testRunWithChroot()

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -12,7 +12,7 @@ class ApplicationTest extends CommandTest
     public function atestVersion()
     {
         $result = $this->runCommand('--version');
-        $this->assertEquals("CacheTool version @package_version@\n", $result);
+        $this->assertSame("CacheTool version @package_version@\n", $result);
     }
 
     public function testWithCli()


### PR DESCRIPTION
assertSame() also asserts that the type is correct and avoids type
juggling.