### PR TITLE
Implement --batch and --exclude options for opcache:compile:scripts command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 .cachetool.yml
 composer.lock
 cachetool.phar

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .cachetool.yml
 composer.lock
 cachetool.phar

--- a/src/Code.php
+++ b/src/Code.php
@@ -39,6 +39,14 @@ class Code
     }
 
     /**
+     * @param string[] $statements
+     */
+    public function addStatements($statements)
+    {
+        $this->code = array_merge($this->code, $statements);
+    }
+
+    /**
      * @return string
      */
     public function getCode()

--- a/src/Command/OpcacheCompileScriptsCommand.php
+++ b/src/Command/OpcacheCompileScriptsCommand.php
@@ -14,6 +14,7 @@ namespace CacheTool\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 
@@ -28,6 +29,18 @@ class OpcacheCompileScriptsCommand extends AbstractCommand
             ->setName('opcache:compile:scripts')
             ->setDescription('Compile scripts from path to the opcode cache')
             ->addArgument('path', InputArgument::REQUIRED)
+            ->addOption(
+                'exclude',
+                null,
+                InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL,
+                'Exclude files from given path'
+            )
+            ->addOption(
+                'batch',
+                null,
+                InputOption::VALUE_NONE,
+                'Compile all files at once, could be useful if pm.max_requests is too low'
+            )
             ->setHelp('');
     }
 
@@ -45,40 +58,70 @@ class OpcacheCompileScriptsCommand extends AbstractCommand
             throw new \RuntimeException('opcache_get_status(): No Opcache status info available.  Perhaps Opcache is disabled via opcache.enable or opcache.enable_cli?');
         }
 
-        $splFiles = $this->prepareFileList($path);
+        $exclude = [];
+        if ($input->hasOption('exclude')) {
+            $exclude = $input->getOption('exclude');
+        }
 
-        $table = new Table($output);
-        $table
-            ->setHeaders([
-                'Compiled',
-                'Filename'
-            ])
-            ->setRows($this->processFilelist($splFiles))
-        ;
-
-        $table->render();
+        $splFiles = $this->prepareFileList($path, $exclude);
+        if ($input->getOption('batch')) {
+            $this->compileBatch($splFiles, $output);
+        } else {
+            $this->compile($splFiles, $output);
+        }
     }
 
-    protected function processFileList($splFiles)
+    /**
+     * @param \Traversable|\SplFileInfo[] $splFiles
+     * @param OutputInterface $output
+     */
+    protected function compile($splFiles, OutputInterface $output)
     {
-        $list = [];
-
+        $rows = [];
         foreach ($splFiles as $file) {
-            $list[] = [
+            $rows[] = [
                 $this->getCacheTool()->opcache_compile_file($file->getRealPath()),
                 $file->getRealPath()
             ];
         }
 
-        return $list;
+        $table = new Table($output);
+        $table
+            ->setHeaders(['Compiled', 'Filename'])
+            ->setRows($rows)
+        ;
+        $table->render();
+    }
+
+    /**
+     * @param \Traversable|\SplFileInfo[] $splFiles
+     * @param OutputInterface $output
+     */
+    protected function compileBatch($splFiles, OutputInterface $output)
+    {
+        $paths = [];
+        foreach ($splFiles as $file) {
+            $paths []= $file->getRealPath();
+        }
+
+        $compiled = $this->getCacheTool()->opcache_compile_files($paths);
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(['Compiled'])
+            ->setRows([[$compiled]])
+        ;
+
+        $table->render();
     }
 
     /**
      * @param string $path
+     * @param array $exclude
      *
      * @return \Traversable|\SplFileInfo[]
      */
-    private function prepareFileList($path)
+    private function prepareFileList($path, $exclude = [])
     {
         return Finder::create()
             ->files()
@@ -86,6 +129,7 @@ class OpcacheCompileScriptsCommand extends AbstractCommand
             ->name('*.php')
             ->notPath('/Tests/')
             ->notPath('/tests/')
+            ->notPath($exclude)
             ->ignoreUnreadableDirs()
             ->ignoreDotFiles(true)
             ->ignoreVCS(true);

--- a/src/Proxy/OpcacheProxy.php
+++ b/src/Proxy/OpcacheProxy.php
@@ -84,7 +84,7 @@ class OpcacheProxy implements ProxyInterface
         $code = new Code();
         $code->addStatement('$paths = [');
         foreach ($files as $file) {
-            $code->addStatement(sprintf('%s,', var_export($file, true)));
+            $code->addStatement(sprintf('    %s,', var_export($file, true)));
         }
 
         $code->addStatement('];');

--- a/tests/Proxy/OpcacheProxyTest.php
+++ b/tests/Proxy/OpcacheProxyTest.php
@@ -6,7 +6,7 @@ class OpcacheProxyTest extends ProxyTest
 {
     public function testGetFunctions()
     {
-        $this->assertCount(6, $this->createProxyInstance()->getFunctions());
+        $this->assertCount(7, $this->createProxyInstance()->getFunctions());
     }
 
     public function testFunctions()

--- a/tests/Proxy/OpcacheProxyTest.php
+++ b/tests/Proxy/OpcacheProxyTest.php
@@ -12,6 +12,19 @@ class OpcacheProxyTest extends ProxyTest
     public function testFunctions()
     {
         $this->assertProxyCode("return opcache_compile_file('file');", 'opcache_compile_file', ['file']);
+        $this->assertProxyCode(join(PHP_EOL, [
+            '$paths = [',
+            "    'file1',",
+            "    'file2',",
+            '];',
+            'foreach ($paths as $path) {',
+            '    $compiled = opcache_compile_file($path);',
+            '    if (!$compiled) {',
+            '        return false;',
+            '    }',
+            '}',
+            'return true;'
+        ]), 'opcache_compile_files', [['file1', 'file2']]);
         $this->assertProxyCode("return opcache_get_configuration();", 'opcache_get_configuration', []);
         $this->assertProxyCode("return opcache_get_status(true);", 'opcache_get_status', [true]);
         $this->assertProxyCode("return opcache_invalidate('key', true);", 'opcache_invalidate', ['key', true]);


### PR DESCRIPTION
Option `--batch` allows to compile all files at once (in single php file). It could help warming up opcache on servers with `pm.max_requests` setting (when project has big amount of files, php-fpm stops responding after compiling `pm.max_requests` - 1 files).

Option `--exclude` allows to exclude paths, opcache for which we don't want to compile. For example we don't want to compile opcache for `vendor/` directory.