### PR TITLE
Test enhancement

### DIFF
--- a/tests/Adapter/CliTest.php
+++ b/tests/Adapter/CliTest.php
@@ -3,6 +3,7 @@
 namespace CacheTool\Adapter;
 
 use CacheTool\Code;
+use Monolog\Logger;
 
 class CliTest extends \PHPUnit\Framework\TestCase
 {
@@ -10,7 +11,7 @@ class CliTest extends \PHPUnit\Framework\TestCase
     {
         $cli = new Cli();
         $cli->setTempDir(sys_get_temp_dir());
-        $cli->setLogger($this->getMockBuilder('Monolog\Logger')->disableOriginalConstructor()->getMock());
+        $cli->setLogger($this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock());
 
         $code = Code::fromString('return true;');
 
@@ -26,7 +27,7 @@ class CliTest extends \PHPUnit\Framework\TestCase
     {
         $cli = new Cli();
         $cli->setTempDir(sys_get_temp_dir());
-        $cli->setLogger($this->getMockBuilder('Monolog\Logger')->disableOriginalConstructor()->getMock());
+        $cli->setLogger($this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock());
 
         $code = Code::fromString('throw new \Exception("test");');
         $result = $cli->run($code);
@@ -36,7 +37,7 @@ class CliTest extends \PHPUnit\Framework\TestCase
     {
         $cli = new Cli();
         $cli->setTempDir(sys_get_temp_dir());
-        $cli->setLogger($this->getMockBuilder('Monolog\Logger')->disableOriginalConstructor()->getMock());
+        $cli->setLogger($this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock());
 
         $code = Code::fromString('return PHP_BINARY;');
 

--- a/tests/Adapter/FastCGITest.php
+++ b/tests/Adapter/FastCGITest.php
@@ -4,6 +4,9 @@ namespace CacheTool\Adapter;
 
 use CacheTool\Code;
 use CacheTool\PhpFpmRunner;
+use CacheTool\Adapter\FastCGI;
+use Monolog\Logger;
+use Adoy\FastCGI\Client;
 
 class FastCGITest extends \PHPUnit\Framework\TestCase
 {
@@ -12,7 +15,7 @@ class FastCGITest extends \PHPUnit\Framework\TestCase
         $fpm = new PhpFpmRunner();
         $fcgi = new FastCGI($fpm->socket);
         $fcgi->setTempDir(sys_get_temp_dir());
-        $fcgi->setLogger($this->getMockBuilder('Monolog\Logger')->disableOriginalConstructor()->getMock());
+        $fcgi->setLogger($this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock());
 
         $code = Code::fromString('return true;');
 
@@ -43,7 +46,7 @@ class FastCGITest extends \PHPUnit\Framework\TestCase
 
     public function testRunWithChroot()
     {
-        $fcgi = $this->getMockBuilder('\CacheTool\Adapter\FastCGI')
+        $fcgi = $this->getMockBuilder(FastCGI::class)
             ->setMethods(['getScriptFileName'])
             ->setConstructorArgs([null, sys_get_temp_dir()])
             ->getMock();
@@ -52,7 +55,7 @@ class FastCGITest extends \PHPUnit\Framework\TestCase
         $reflectionClient = $reflection->getProperty('client');
         $reflectionClient->setAccessible(true);
 
-        $clientMock = $this->getMockBuilder('\Adoy\FastCGI\Client')
+        $clientMock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->getMock();
         $reflectionClient->setValue($fcgi, $clientMock);
@@ -78,7 +81,7 @@ class FastCGITest extends \PHPUnit\Framework\TestCase
             ->willReturn("Content-type: text/html; charset=UTF-8\r\n\r\na:2:{s:6:\"result\";b:1;s:6:\"errors\";a:0:{}}");
 
         $fcgi->setTempDir(sys_get_temp_dir());
-        $fcgi->setLogger($this->getMockBuilder('Monolog\Logger')->disableOriginalConstructor()->getMock());
+        $fcgi->setLogger($this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock());
 
         $code = Code::fromString('return true;');
 

--- a/tests/Adapter/WebTest.php
+++ b/tests/Adapter/WebTest.php
@@ -3,19 +3,21 @@
 namespace CacheTool\Adapter;
 
 use CacheTool\Code;
+use Monolog\Logger;
+use CacheTool\Adapter\Http\FileGetContents;
 
 class WebTest extends \PHPUnit\Framework\TestCase
 {
     public function testRun()
     {
-        $httpMock = $this->getMockBuilder('CacheTool\Adapter\Http\FileGetContents')->disableOriginalConstructor()->getMock();
+        $httpMock = $this->getMockBuilder(FileGetContents::class)->disableOriginalConstructor()->getMock();
         $httpMock
             ->method('fetch')
             ->willReturn(serialize(['errors' => [], 'result' => true]));
 
         $web = new Web(sys_get_temp_dir(), $httpMock);
         $web->setTempDir(sys_get_temp_dir());
-        $web->setLogger($this->getMockBuilder('Monolog\Logger')->disableOriginalConstructor()->getMock());
+        $web->setLogger($this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock());
 
         $code = Code::fromString('return true;');
 

--- a/tests/CacheToolTest.php
+++ b/tests/CacheToolTest.php
@@ -11,7 +11,7 @@ class CacheToolTest extends \PHPUnit\Framework\TestCase
     public function testConstruct()
     {
         $cachetool = new CacheTool();
-        $this->assertInstanceOf('CacheTool\CacheTool', $cachetool);
+        $this->assertInstanceOf(CacheTool::class, $cachetool);
     }
 
     public function testFactory()
@@ -49,7 +49,7 @@ class CacheToolTest extends \PHPUnit\Framework\TestCase
         $cachetool = CacheTool::factory($adapter, $tempDir, $this->getLogger());
         $this->assertSame($tempDir, $cachetool->getTempDir());
     }
-    
+
     /**
      * @expectedException \InvalidArgumentException
      */
@@ -70,6 +70,6 @@ class CacheToolTest extends \PHPUnit\Framework\TestCase
 
     protected function getLogger()
     {
-        return $this->getMockBuilder('Monolog\Logger')->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock();
     }
 }

--- a/tests/CodeTest.php
+++ b/tests/CodeTest.php
@@ -74,14 +74,14 @@ class CodeTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(strlen($result) > 0);
 
         $unserialized = @unserialize($result);
-        $this->assertTrue(is_array($unserialized));
+        $this->assertIsArray($unserialized);
 
         $this->assertCount(2, $unserialized);
         $this->assertArrayHasKey('result', $unserialized);
         $this->assertArrayHasKey('errors', $unserialized);
 
         $this->assertSame(10, $unserialized['result']);
-        $this->assertTrue(is_array($unserialized['errors']));
+        $this->assertIsArray($unserialized['errors']);
         $this->assertCount(0, $unserialized['errors']);
     }
 
@@ -166,7 +166,7 @@ class CodeTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(strlen($result) > 0);
 
         $unserialized = unserialize($result);
-        $this->assertTrue(is_array($unserialized));
+        $this->assertIsArray($unserialized);
 
         $this->assertCount(2, $unserialized);
         $this->assertArrayHasKey('result', $unserialized);


### PR DESCRIPTION
# Changed log
- Using `::class` to do instance call.
- Using `assertIsArray` to assert expected value type is `array`.
- Removing additional white spaces.