### PR TITLE
PHP Eval and File Commands

### DIFF
--- a/src/Command/PHPEvalCommand.php
+++ b/src/Command/PHPEvalCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of CacheTool.
+ *
+ * (c) Samuel Gordalina <samuel.gordalina@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CacheTool\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PHPEvalCommand extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('php:eval')
+            ->setDescription('Run a specified PHP code')
+            ->addArgument('code', InputArgument::REQUIRED)
+            ->setHelp('In order to use this your PHP code needs to return the value you want to see
+            example: "return gethostname();"');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $code = $input->getArgument('code');
+        $success = $this->getCacheTool()->_eval($code);
+        $output->writeln(sprintf("<comment>Eval Output:\n <info>%s</info></comment>", $success));
+        return 0;
+    }
+}

--- a/src/Command/PHPFileCommand.php
+++ b/src/Command/PHPFileCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of CacheTool.
+ *
+ * (c) Samuel Gordalina <samuel.gordalina@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CacheTool\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PHPFileCommand extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('php:file')
+            ->setDescription('Run a specified file')
+            ->addArgument('file', InputArgument::REQUIRED)
+            ->setHelp('');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $file = $input->getArgument('file');
+        if (!file_exists($file)) {
+            throw new \RuntimeException("file not found");
+            return 1;
+        }
+
+        $code = file_get_contents($file);
+        $code = str_replace('<?php','',$code); 
+        $success = $this->getCacheTool()->_eval($code);
+        $output->writeln(sprintf("<comment>File Output:\n <info>%s</info></comment>", $success));
+        return 0;
+    }
+}

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -84,6 +84,8 @@ class Application extends BaseApplication
             $commands[] = new CacheToolCommand\OpcacheCompileScriptCommand();
         }
 
+        $commands[] = new CacheToolCommand\PHPEvalCommand();
+        $commands[] = new CacheToolCommand\PHPFileCommand();
         $commands[] = new CacheToolCommand\StatCacheClearCommand();
         $commands[] = new CacheToolCommand\StatRealpathGetCommand();
         $commands[] = new CacheToolCommand\StatRealpathSizeCommand();


### PR DESCRIPTION
# Summary

Added a php:eval and php:file command that allows for the execution of arbitrary PHP code. 
First pass doesn't change the functionality of the executable code template so requires specific formatting to return the output you want from the PHP code.

This is in response to a personal need and request posted here #100  

Let me know what additional error checking, etc.. you'd be looking for. 

# Eval Command:

Example: 
` ./bin/cachetool --cli php:eval "return phpversion();"`
Eval Output:
  7.4.5

# File Command
`./bin/cachetool --cli php:file test.php`
File Output:
 7.4.5

test.php:
`<?php
function getversion() {
  return phpversion();
}
return getversion();`