### PR TITLE
Update README : tmpdir readable by php-fpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Troubleshooting
 > Content-type: text/html; charset=UTF-8
 > No input file specified.
 
-This means that cachetool could not write to `/dev/shm` provide a directory that cachetool can write to through `php cachetool.phar --tmp-dir=/writable/dir` or configuration.
+This means that cachetool could not write to `/dev/shm` provide a directory that cachetool can write to through `php cachetool.phar --tmp-dir=/writable/dir` or configuration. This directory should also be readable by the web user running php-fpm/apache.
 
 License
 -------


### PR DESCRIPTION
On configuration with separate users for the cli and for php-fpm, using /tmp/ or another dir may not always work.

On some systems the web user cannot read /tmp/