### PR TITLE
Pin version of consolidation/self-update to 1.1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/finder": "^4.0|^5.0",
         "symfony/process": "^4.0|^5.0",
         "symfony/yaml": "^4.0|^5.0",
-        "consolidation/self-update": "1.x-dev"
+        "consolidation/self-update": "1.1.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57bd863368091a5ed34fd68f082efec5",
+    "content-hash": "7051d4402e87e7b7aa3aec13faefbb3c",
     "packages": [
         {
             "name": "consolidation/self-update",
-            "version": "dev-main",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/self-update.git",
-                "reference": "ed68ed69a427a03bb6fd2197e6d3d564a5ce0cba"
+                "reference": "a887734f50e67e89b441c0d945e817ec8c02254c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/self-update/zipball/ed68ed69a427a03bb6fd2197e6d3d564a5ce0cba",
-                "reference": "ed68ed69a427a03bb6fd2197e6d3d564a5ce0cba",
+                "url": "https://api.github.com/repos/consolidation/self-update/zipball/a887734f50e67e89b441c0d945e817ec8c02254c",
+                "reference": "a887734f50e67e89b441c0d945e817ec8c02254c",
                 "shasum": ""
             },
             "require": {
@@ -25,7 +25,6 @@
                 "symfony/console": "^2.8|^3|^4|^5",
                 "symfony/filesystem": "^2.5|^3|^4|^5"
             },
-            "default-branch": true,
             "bin": [
                 "scripts/release"
             ],
@@ -57,9 +56,9 @@
             "description": "Provides a self:update command for Symfony Console applications.",
             "support": {
                 "issues": "https://github.com/consolidation/self-update/issues",
-                "source": "https://github.com/consolidation/self-update/tree/main"
+                "source": "https://github.com/consolidation/self-update/tree/1.1.6"
             },
-            "time": "2020-12-18T03:34:58+00:00"
+            "time": "2020-12-18T03:34:51+00:00"
         },
         {
             "name": "hollodotme/fast-cgi-client",
@@ -3501,9 +3500,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "consolidation/self-update": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
To avoid issues with composer minimum stabilities we need to pin the version to 1.1.6