### PR TITLE
Use stable releases for consolidation/self-update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/finder": "^4.0|^5.0",
         "symfony/process": "^4.0|^5.0",
         "symfony/yaml": "^4.0|^5.0",
-        "consolidation/self-update": "1.x-dev"
+        "consolidation/self-update": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57bd863368091a5ed34fd68f082efec5",
+    "content-hash": "21069d1ba14915cc013d74bc1a7ce37e",
     "packages": [
         {
             "name": "consolidation/self-update",
@@ -3501,9 +3501,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "consolidation/self-update": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Avoids reducing composer minimum-stability when installing with
`composer require` on production servers.

Fix #171