### PR TITLE
Add SymfonyHttpClient file configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@ fastcgi: /var/run/php5-fpm.sock
 temp_dir: /dev/shm/cachetool
 ```
 
+Example for the web adapter:
+
+```yml
+adapter: web
+webClient: SymfonyHttpClient # defaults to FileGetContents
+webUrl: http://example.com
+webPath: /var/www/example.com/current/web
+webBasicAuth: user:password
+```
+
 You can define the supported extensions in the config file. By default, `apcu`,
 and `opcache` are enabled. To disable `apcu`, add this to your config file:
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -196,22 +196,27 @@ class Application extends BaseApplication
             }
         } elseif ($input->hasParameterOption('--web')) {
             $this->config['adapter'] = 'web';
+            $this->config['webClient'] = $input->hasParameterOption('--web') ?? 'FileGetContents';
             $this->config['webPath'] = $input->getParameterOption('--web-path');
             $this->config['webUrl'] = $input->getParameterOption('--web-url');
+            if($this->config['webClient'] === 'SymfonyHttpClient') {
+                if ($input->hasParameterOption('--web-allow-insecure')) {
+                    $this->config['webAllowInsecure'] = true;
+                }
 
-            switch ($input->getParameterOption('--web') ?? 'FileGetContents') {
+                if ($input->hasParameterOption('--web-basic-auth')) {
+                    $this->config['webBasicAuth'] = $input->getParameterOption('--web-basic-auth');
+                }
+            }
+        }
+
+        if ($this->config['adapter'] === 'web') {
+            switch ($this->config['webClient']) {
                 case 'FileGetContents':
                     $this->config['http'] = new FileGetContents($this->config['webUrl']);
                     break;
 
                 case 'SymfonyHttpClient':
-                    if ($input->hasParameterOption('--web-allow-insecure')) {
-                        $this->config['webAllowInsecure'] = true;
-                    }
-
-                    if ($input->hasParameterOption('--web-basic-auth')) {
-                        $this->config['webBasicAuth'] = $input->getParameterOption('--web-basic-auth');
-                    }
 
                     $symfonyHttpClientConfig = [];
 
@@ -228,8 +233,6 @@ class Application extends BaseApplication
                     break;
 
                 default:
-                    var_dump($this->config);
-                    var_dump($input->getParameterOption('--web', "LOL"));
                     throw new \RuntimeException("{$this->config["web"]} is not a valid adapter. Possible adapters: FileGetContents or SymfonyHttpClient");
             }
         }

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -112,6 +112,27 @@ class ApplicationTest extends CommandTest
         $this->assertSame(42, $code);
     }
 
+    public function testWebSymfonyHttpClientCustomConfigFile()
+    {
+        $temp = tempnam(sys_get_temp_dir(), "cfg");
+        file_put_contents($temp, '
+adapter: web
+webClient: SymfonyHttpClient
+webUrl: http://example.com
+webPath: /var/www/example.com/current/web
+webBasicAuth: user:password
+');
+
+        $app = new Application(new Config());
+        $app->add(new DummyCommand);
+        $app->setAutoExit(false);
+
+        $output = new BufferedOutput();
+        $code = $app->run(new StringInput("dummy --config=$temp"), $output);
+
+        $this->assertSame(42, $code);
+    }
+
     public function testNoSupportedExtensions()
     {
         $app = new Application(new Config(['extensions' => []]));


### PR DESCRIPTION
Unfortunately, current implementation does not allow to use `SymfonyHttpClient` in the config file.

This PR decouples the `http` object creation logic from the config parsing.

However, there's still some inconsistencies because `Config` object properties and cli/file parameters are being merged/mixed up/not consistently named (`temp_dir` / `webAllowInsecure`).