### PR TITLE
Update Formatter.php

### DIFF
--- a/src/Util/Formatter.php
+++ b/src/Util/Formatter.php
@@ -43,6 +43,7 @@ class Formatter
             } else {
                 $date = new \DateTime($date);
             }
+            $date->setTimezone(new DateTimeZone(date_default_timezone_get()));
         }
 
         return $date->format(\DateTime::RFC2822);


### PR DESCRIPTION
As cachetool create a DateTime with the 'U' format (timestamp), the timezone is ignored (as the PHP documentation says : https://www.php.net/manual/fr/datetime.createfromformat.php).
I added this line in order to have a "cachetool opcache:status" in the server's timezone.