### PR TITLE
chore: upgraded psr/log dependency version (added compatibility to ^v1|^v2|^v3)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "hollodotme/fast-cgi-client": "^3.0",
         "monolog/monolog": "^1.0|^2.0",
         "php": ">=8.0.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "symfony/console": "^4.0|^5.0|^6.0",
         "symfony/dependency-injection": "^4.0|^5.0|^6.0",
         "symfony/finder": "^4.0|^5.0|^6.0",


### PR DESCRIPTION
Hey, thank you for your work, I just discovered this package.

I first used it with the cachetool.phar and saw that it can be added as a project dependency.

In a fresh SF6 app with `symfony/cache`, it was not possible to run `composer require gordalina/cachetool` as psr/log was in version 3.0 (see the above log).

I could have run `composer require gordalina/cachetoo -W` to downgrade `psr/log` but maybe this PR is usefull for you anyway.

Please feel free to give me your feedback if it was a good idea or not.


Logs:

  Problem 1
    - Root composer.json requires gordalina/cachetool ^8.1 -> satisfiable by gordalina/cachetool[8.1.0].
    - gordalina/cachetool 8.1.0 requires psr/log ^1.0 -> found psr/log[1.0.0, ..., 1.1.4] but the package is fixed to 3.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.