### PR TITLE
Try fixing race conditions between --web file creation and HTTP access

### DIFF
--- a/src/Adapter/Web.php
+++ b/src/Adapter/Web.php
@@ -34,6 +34,10 @@ class Web extends AbstractAdapter
         $file = $this->createWebFile($filename);
         $code->writeTo($file);
 
+        // @todo this is so far only for testing if this solves issues with that URL not 
+        // being immediately available (404 is returned in that case).
+        sleep(3);
+
         $content = $this->http->fetch($filename);
 
         if (!@unlink($file)) {


### PR DESCRIPTION
On some hosters' storage systems it happens that although the cache busting PHP file is created fine, 
the subsequent access via HTTP fails (404).

This PR is to explore possiblities how to make `cachetool` more resilient against that.

The first step is just to see if sleep() between creation and HTTP-accessing would help.
Of course that would have to be configurable if that approach is chosen.

Other possiblities might be to retry `$this->http->fetch()` some times (maybe each second or so, max. 5 tries?).

If others want to try that in their pipelines: In a composer project, the easiest is to install `cweagans/composer-patches` and configure by:

```
"extra": {
  "patches": {
    "gordalina/cachetool": {
      "Try fixing race conditions between --web file creation and HTTP access": "https://patch-diff.githubusercontent.com/raw/gordalina/cachetool/pull/210.patch"
    }
  }
}
```
The patch applies to v7 and v8.

I am happy to get feedback.


Relates: #209
