### PR TITLE
Always use full paths in opcache:*:scripts commands

### DIFF
--- a/src/Command/OpcacheInvalidateScriptsCommand.php
+++ b/src/Command/OpcacheInvalidateScriptsCommand.php
@@ -66,7 +66,7 @@ class OpcacheInvalidateScriptsCommand extends AbstractOpcacheCommand
         sort($cacheList);
 
         foreach ($cacheList as $item) {
-            $filename = $this->processFilename($item['full_path']);
+            $filename = $item['full_path'];
             if (preg_match('|' . $path . '|', $filename)) {
                 $toInvalidate[] = $filename;
             }
@@ -79,16 +79,5 @@ class OpcacheInvalidateScriptsCommand extends AbstractOpcacheCommand
         }
 
         return $processed;
-    }
-
-    protected function processFilename($filename)
-    {
-        $dir = getcwd();
-
-        if (0 === strpos($filename, $dir)) {
-            return "." . substr($filename, strlen($dir));
-        }
-
-        return $filename;
     }
 }

--- a/src/Command/OpcacheStatusScriptsCommand.php
+++ b/src/Command/OpcacheStatusScriptsCommand.php
@@ -62,21 +62,10 @@ class OpcacheStatusScriptsCommand extends AbstractOpcacheCommand
             $list[] = [
                 number_format($item['hits']),
                 Formatter::bytes($item['memory_consumption']),
-                $this->processFilename($item['full_path']),
+                $item['full_path'],
             ];
         }
 
         return $list;
-    }
-
-    protected function processFilename($filename)
-    {
-        $dir = getcwd();
-
-        if (0 === strpos($filename, $dir)) {
-            return "." . substr($filename, strlen($dir));
-        }
-
-        return $filename;
     }
 }


### PR DESCRIPTION
Stop shortening the path based on the current working directory, this
reduces confusion and allows for consistent cache handling.

Fixes #78