### PR TITLE
Parse --web option correctly

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -198,7 +198,7 @@ class Application extends BaseApplication
             }
         } elseif ($input->hasParameterOption('--web')) {
             $this->config['adapter'] = 'web';
-            $this->config['webClient'] = $input->getParameterOption('--web');
+            $this->config['webClient'] = $input->getOption('web') ?? 'FileGetContents';
             $this->config['webPath'] = $input->getParameterOption('--web-path');
             $this->config['webUrl'] = $input->getParameterOption('--web-url');
 


### PR DESCRIPTION
`getParameterOption` returns the unparsed / unvalidated result of the option, which might result in incorrect results when reordering options:

```
php cachetool.phar opcache:status --web --web-path=/var/www
```

returns --web-path=/var/www as the value for the --web option when using `getParameterOption`, getting the parsed result is done by using `getOption` which returns the correctly parsed value, in this case `NULL`, which should result in the default being set which is FileGetContents.

This avoids the warning that the webclient is unkown when passing --web without specifying the client.