### PR TITLE
Skip sslip.io tests if DNS is not configured

### DIFF
--- a/tests/Adapter/Http/FileGetContentsTest.php
+++ b/tests/Adapter/Http/FileGetContentsTest.php
@@ -31,7 +31,13 @@ class FileGetContentsTest extends \PHPUnit\Framework\TestCase
 
     public function testFetchUnderscores()
     {
-        $client = new SymfonyHttpClient('http://_.127.0.0.1.sslip.io:9999');
+        $sslipHostname = '_.127.0.0.1.sslip.io';
+        if (!gethostbynamel($sslipHostname)) {
+            $this->markTestSkipped(
+                "{$sslipHostname} does not resolve, sslip  DNS is not configured correctly, skipping."
+            );
+        }
+        $client = new SymfonyHttpClient("http://{$sslipHostname}:9999");
         $this->assertStringStartsWith('# CacheTool', $client->fetch('README.md'));
     }
 

--- a/tests/Adapter/Http/SymfonyHttpClientTest.php
+++ b/tests/Adapter/Http/SymfonyHttpClientTest.php
@@ -31,7 +31,13 @@ class SymfonyHttpClientTest extends \PHPUnit\Framework\TestCase
 
     public function testFetchUnderscores()
     {
-        $client = new SymfonyHttpClient('http://_.127.0.0.1.sslip.io:9999');
+        $sslipHostname = '_.127.0.0.1.sslip.io';
+        if (!gethostbynamel($sslipHostname)) {
+            $this->markTestSkipped(
+                "{$sslipHostname} does not resolve, sslip  DNS is not configured correctly, skipping."
+            );
+        }
+        $client = new SymfonyHttpClient("http://{$sslipHostname}:9999");
         $this->assertStringStartsWith('# CacheTool', $client->fetch('README.md'));
     }
 


### PR DESCRIPTION
In case sslip.io DNS is not configured correctly on the running host the tests will fail, skip instead in this case as the failure would not be related to a failing code but dependend on the running hosts DNS configuration.