### PR TITLE
Fix deprecated string interpolation in v8

### DIFF
--- a/src/Adapter/FastCGI.php
+++ b/src/Adapter/FastCGI.php
@@ -79,7 +79,7 @@ class FastCGI extends AbstractAdapter
             if (preg_match($IPv6, $host) === 1) {
                 // IPv6 addresses need to be surrounded by brackets
                 // see: https://www.php.net/manual/en/function.stream-socket-client.php#refsect1-function.stream-socket-client-notes
-                $host = "[${host}]";
+                $host = "[{$host}]";
             }
 
             $this->connection = new NetworkSocket(

--- a/src/Adapter/Http/FileGetContents.php
+++ b/src/Adapter/Http/FileGetContents.php
@@ -24,7 +24,7 @@ class FileGetContents extends AbstractHttp
                 'errors' => [
                     [
                         'no' => 0,
-                        'str' => "file_get_contents() call failed with url: ${url}",
+                        'str' => "file_get_contents() call failed with url: {$url}",
                     ],
                 ],
             ]);

--- a/src/Command/AbstractOpcacheCommand.php
+++ b/src/Command/AbstractOpcacheCommand.php
@@ -24,7 +24,7 @@ abstract class AbstractOpcacheCommand extends AbstractCommand
 
         if ($info['restart_pending'] ?? false) {
             $cacheStatus = $info['cache_full'] ? 'Also, you cache is full.' : '';
-            throw new \RuntimeException("OPCache is restart, as such files can't be invalidated. Try again later. ${cacheStatus}");
+            throw new \RuntimeException("OPCache is restart, as such files can't be invalidated. Try again later. {$cacheStatus}");
         }
 
         $file_cache_only = $info['file_cache_only'] ?? false;

--- a/src/Command/OpcacheResetFileCacheCommand.php
+++ b/src/Command/OpcacheResetFileCacheCommand.php
@@ -44,7 +44,7 @@ class OpcacheResetFileCacheCommand extends AbstractOpcacheCommand
 
         if (!$input->getOption('force')) {
             $question = new ConfirmationQuestion(
-                "Are you sure you want to delete the contents of <comment>${fileCache}</comment>? [no] ",
+                "Are you sure you want to delete the contents of <comment>{$fileCache}</comment>? [no] ",
                 false,
                 '/^y/i'
             );


### PR DESCRIPTION
I know this is already fixed in v9 but right now I'm not able to upgrade because of some dependencies conflicts, but I'm already using PHP 8.2 and I'm getting some errors because of these string interpolations.

It would be nice if you could submit this minor fix to v8.

Thx