### PR TITLE
improve phpdoc return type for apcu_cache_info

### DIFF
--- a/src/CacheTool.php
+++ b/src/CacheTool.php
@@ -18,7 +18,7 @@ use Monolog\Logger;
 
 /**
  * @method mixed apcu_add(mixed $key, mixed $var, int $ttl = 0)
- * @method boolean apcu_cache_info(boolean $limited = false)
+ * @method false|array apcu_cache_info(boolean $limited = false)
  * @method boolean|array apcu_regexp_get_keys(?string $regexp = null)
  * @method boolean apcu_cas(string $key, int $old, int $new)
  * @method boolean apcu_clear_cache()

--- a/src/Proxy/ApcuProxy.php
+++ b/src/Proxy/ApcuProxy.php
@@ -117,7 +117,7 @@ class ApcuProxy implements ProxyInterface
      * @since  2.0.0
      * @param  boolean $limited    If limited is TRUE, the return value will exclude the individual list of cache
      *                             entries. This is useful when trying to optimize calls for statistics gathering.
-     * @return boolean             Array of cached data (and meta-data) or FALSE on failure
+     * @return false|array             Array of cached data (and meta-data) or FALSE on failure
      */
     public function apcu_cache_info($limited = false)
     {

--- a/src/Proxy/ApcuProxy.php
+++ b/src/Proxy/ApcuProxy.php
@@ -117,7 +117,7 @@ class ApcuProxy implements ProxyInterface
      * @since  2.0.0
      * @param  boolean $limited    If limited is TRUE, the return value will exclude the individual list of cache
      *                             entries. This is useful when trying to optimize calls for statistics gathering.
-     * @return false|array             Array of cached data (and meta-data) or FALSE on failure
+     * @return false|array         Array of cached data (and meta-data) or FALSE on failure
      */
     public function apcu_cache_info($limited = false)
     {


### PR DESCRIPTION
I was a bit confused by the Intellisense in VSCode since the `apcu_cache_info` seemed to return a boolean according to the doc comment, but when printing the results it was an array. 

It looks like the return value is consistent with the [official documentation](https://www.php.net/manual/en/function.apcu-cache-info.php), so I figured it was a typo in the doc comment and changed the type from `boolean` to `false | array` in the ApcuProxy and CacheTool classes (no actual code was touched).

I don't believe it affects anything beside intellisense, but I'm not sure how other IDE:s handle it.