### PR TITLE
Add ability to exclude files from opcode cache listing

### DIFF
--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -11,6 +11,7 @@
 
 namespace CacheTool\Command;
 
+use CacheTool\CacheTool;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -2,16 +2,57 @@
 
 namespace CacheTool\Command;
 
+use CacheTool\CacheTool;
+use CacheTool\Code;
 use CacheTool\Console\Application;
 use CacheTool\Console\Config;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 abstract class CommandTest extends \PHPUnit\Framework\TestCase
 {
-    public function runCommand($cmd)
+    public function runCommand($cmd, $mockData = null)
     {
-        $app = new Application(new Config(['adapter' => 'cli']));
+        $app = new class($mockData, new Config(['adapter' => 'cli'])) extends Application {
+            protected $mockData;
+            public function __construct($mockData, Config $config)
+            {
+                parent::__construct($config);
+
+                $this->mockData = $mockData;
+            }
+
+            public function buildContainer(InputInterface $input)
+            {
+                $container = parent::buildContainer($input);
+
+                $cacheTool = CacheTool::factory(
+                    new class($this->mockData) extends \CacheTool\Adapter\Cli {
+                        public function __construct(protected $mockData)
+                        {}
+
+                        public function doRun(Code $code)
+                        {
+                            if ($this->mockData) {
+                                $wrappedMockData = [
+                                    'errors' => null,
+                                    'result' => $this->mockData,
+                                ];
+                                return serialize($wrappedMockData);
+                            }
+
+                            return parent::doRun($code);
+                        }
+                    },
+                    $this->config['temp_dir'],
+                    $this->logger
+                );
+                $container->set('cachetool', $cacheTool);
+
+                return $container;
+            }
+        };
         $app->setAutoExit(false);
 
         $input = new StringInput($cmd);

--- a/tests/Command/OpcacheStatusScriptsCommandTest.php
+++ b/tests/Command/OpcacheStatusScriptsCommandTest.php
@@ -15,4 +15,74 @@ class OpcacheStatusScriptsCommandTest extends CommandTest
         $this->assertStringContainsString('Memory', $result);
         $this->assertStringContainsString('Filename', $result);
     }
+
+    public function testExcludingScriptsWorksAsExpected()
+    {
+        $this->assertHasOpcache();
+
+        $scriptsMock = [
+            '/vendor/somefile.php' => [
+                'full_path' => '/vendor/somefile.php',
+                'hits' => 1,
+                'memory_consumption' => 1024,
+            ],
+            '/src/my/path/to/somefile.php' => [
+                'full_path' => '/src/my/path/to/somefile.php',
+                'hits' => 2,
+                'memory_consumption' => 1024,
+            ],
+            '/src/my/other/path/to/somefile.php' => [
+                'full_path' => '/src/my/other/path/to/somefile.php',
+                'hits' => 3,
+                'memory_consumption' => 1024,
+            ],
+            '/vendor/someotherfile.php' => [
+                'full_path' => '/vendor/someotherfile.php',
+                'hits' => 4,
+                'memory_consumption' => 1024,
+            ],
+        ];
+
+        $result = $this->runCommand('opcache:status:scripts -v -e vendor', ['scripts' => $scriptsMock]);
+
+        $this->assertStringContainsString('opcache_get_status(true)', $result);
+        $this->assertStringContainsString('/src/my/path/to/somefile.php', $result);
+        $this->assertStringNotContainsString('vendor', $result); // No findings of "vendor" expected!
+    }
+
+    public function testNoScriptsAreExcludedByDefault()
+    {
+        $this->assertHasOpcache();
+
+        $scriptsMock = [
+            '/vendor/somefile.php' => [
+                'full_path' => '/vendor/somefile.php',
+                'hits' => 1,
+                'memory_consumption' => 1024,
+            ],
+            '/src/my/path/to/somefile.php' => [
+                'full_path' => '/src/my/path/to/somefile.php',
+                'hits' => 2,
+                'memory_consumption' => 1024,
+            ],
+            '/src/my/other/path/to/somefile.php' => [
+                'full_path' => '/src/my/other/path/to/somefile.php',
+                'hits' => 3,
+                'memory_consumption' => 1024,
+            ],
+            '/vendor/someotherfile.php' => [
+                'full_path' => '/vendor/someotherfile.php',
+                'hits' => 4,
+                'memory_consumption' => 1024,
+            ],
+        ];
+
+        $result = $this->runCommand('opcache:status:scripts -v', ['scripts' => $scriptsMock]);
+
+        $this->assertStringContainsString('opcache_get_status(true)', $result);
+        $this->assertStringContainsString('/vendor/somefile.php', $result);
+        $this->assertStringContainsString('/src/my/path/to/somefile.php', $result);
+        $this->assertStringContainsString('/src/my/other/path/to/somefile.php', $result);
+        $this->assertStringContainsString('/vendor/someotherfile.php', $result);
+    }
 }


### PR DESCRIPTION
While inspecting our OPcache scripts, I noticed that most of them were some 3rd party scripts, which were mostly uninteresting for me. So I created an option to exclude some scripts from the listing.

You can now add `--exclude='/vendor/' to exclude all vendor scripts. Note, that this will match _all_ scripts that have `vendor` in their path (there is no way to determine if the script is really a 3rd party script).

The option takes a regex as value, so it would be possible to set `--exclude='.*dor/'` to exclude all paths which have a directory ending with "dor/".

Note: [Delimiters](https://www.php.net/manual/de/regexp.reference.delimiters.php) are added automatically (I chose bracket style delimiters).