### PR TITLE
Add CLI flag to retry HTTP requests

### DIFF
--- a/src/Adapter/Http/AbstractHttp.php
+++ b/src/Adapter/Http/AbstractHttp.php
@@ -13,6 +13,9 @@ namespace CacheTool\Adapter\Http;
 
 abstract class AbstractHttp implements HttpInterface
 {
+    // Default delay between HTTP retries
+    protected const DEFAULT_DELAY_MS = 100;
+
     protected $baseUrl;
 
     public function __construct($baseUrl)

--- a/src/Adapter/Http/SymfonyHttpClient.php
+++ b/src/Adapter/Http/SymfonyHttpClient.php
@@ -12,15 +12,24 @@
 namespace CacheTool\Adapter\Http;
 
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
+use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Component\HttpFoundation\Response;
 
 class SymfonyHttpClient extends AbstractHttp
 {
     private $client;
 
-    public function __construct($baseUrl, $httpClientConfig = [])
+    public function __construct($baseUrl, $httpClientConfig = [], int $maxRetries = 0, int $delayMs = self::DEFAULT_DELAY_MS)
     {
         $this->client = HttpClient::create($httpClientConfig);
+        if ($maxRetries > 0) {
+            $this->client = new RetryableHttpClient(
+                $this->client,
+                new GenericRetryStrategy(GenericRetryStrategy::DEFAULT_RETRY_STATUS_CODES, $delayMs),
+                $maxRetries,
+            );
+        }
         parent::__construct($baseUrl);
     }
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -114,6 +114,7 @@ class Application extends BaseApplication
         $definition->addOption(new InputOption('--web-allow-insecure', null, InputOption::VALUE_NONE, 'If specified, verify_peer and verify_host are disabled (only for SymfonyHttpClient)'));
         $definition->addOption(new InputOption('--web-basic-auth', null, InputOption::VALUE_OPTIONAL, 'If specified, used for basic authorization (only for SymfonyHttpClient)'));
         $definition->addOption(new InputOption('--web-host', null, InputOption::VALUE_OPTIONAL, 'If specified, adds a Host header to web adapter request (only for SymfonyHttpClient)'));
+        $definition->addOption(new InputOption('--web-retry', null, InputOption::VALUE_REQUIRED, 'If specified, failed HTTP requests will be retried for the specified amount of times'));
         $definition->addOption(new InputOption('--tmp-dir', '-t', InputOption::VALUE_REQUIRED, 'Temporary directory to write files to'));
         $definition->addOption(new InputOption('--config', '-c', InputOption::VALUE_REQUIRED, 'If specified use this yaml configuration file'));
         return $definition;
@@ -198,6 +199,7 @@ class Application extends BaseApplication
             $this->config['webClient'] = $input->getOption('web') ?? 'FileGetContents';
             $this->config['webPath'] = $input->getOption('web-path') ?? $this->config['webPath'];
             $this->config['webUrl'] = $input->getOption('web-url') ?? $this->config['webUrl'];
+            $this->config['webRetry'] = $input->getOption('web-retry') ?? $this->config['webRetry'];
 
             if ($this->config['webClient'] === 'SymfonyHttpClient') {
                 $this->config['webAllowInsecure'] = $input->getOption('web-allow-insecure');
@@ -214,7 +216,7 @@ class Application extends BaseApplication
     }
 
     /**
-     * @return \CacheTool\Adapter\HttpInterface
+     * @return \CacheTool\Adapter\Http\HttpInterface
      */
     private function buildHttpClient()
     {
@@ -236,7 +238,7 @@ class Application extends BaseApplication
                 $options['headers']['Host'] = $this->config['webHost'];
             }
 
-            return new SymfonyHttpClient($this->config['webUrl'], $options);
+            return new SymfonyHttpClient($this->config['webUrl'], $options, $this->config['webRetry']);
         }
 
         if ($this->config['webClient'] !== 'FileGetContents') {
@@ -246,7 +248,7 @@ class Application extends BaseApplication
             ));
         }
 
-        return new FileGetContents($this->config['webUrl']);
+        return new FileGetContents($this->config['webUrl'], $this->config['webRetry']);
     }
 
     /**

--- a/src/Console/Config.php
+++ b/src/Console/Config.php
@@ -29,6 +29,7 @@ class Config implements \ArrayAccess
         'webAllowInsecure' => null,
         'webBasicAuth' => null,
         'webHost' => null,
+        'webRetry' => 3,
 
         'http' => null,
     ];

--- a/tests/Adapter/Http/FileGetContentsTest.php
+++ b/tests/Adapter/Http/FileGetContentsTest.php
@@ -7,30 +7,58 @@ use Symfony\Component\Process\Process;
 
 class FileGetContentsTest extends \PHPUnit\Framework\TestCase
 {
-    /** @var Process */
-    private static $process;
+    private static ?Process $process = null;
 
-    public static function setUpBeforeClass(): void
+    private static function startServer(int $wait = 100000): void
     {
+        // Server is already running
+        if (self::$process instanceof Process) {
+            return;
+        }
+
         self::$process = new Process(['php', '-S', '127.0.0.1:9999', '-t', '.']);
         self::$process->start();
 
-        usleep(100000); //wait for server to get going
+        if ($wait) {
+            usleep($wait); //wait for server to get going
+        }
+    }
+
+    private static function stopServer(): void
+    {
+        // Do nothing if server is not running
+        if (!self::$process instanceof Process) {
+            return;
+        }
+
+        self::$process->stop();
+        self::$process = null;
     }
 
     public static function tearDownAfterClass(): void
     {
-        self::$process->stop();
+        // Make sure to stop server after all tests
+        self::stopServer();
     }
 
     public function testFetch()
     {
+        self::startServer();
         $client = new FileGetContents('http://localhost:9999');
+        $this->assertStringStartsWith('# CacheTool', $client->fetch('README.md'));
+    }
+
+    public function testFetchRetry(): void
+    {
+        self::stopServer();
+        self::startServer(0);
+        $client = new FileGetContents('http://localhost:9999', 10, 10);
         $this->assertStringStartsWith('# CacheTool', $client->fetch('README.md'));
     }
 
     public function testFetchUnderscores()
     {
+        self::startServer();
         $sslipHostname = '_.127.0.0.1.sslip.io';
         if (!gethostbynamel($sslipHostname)) {
             $this->markTestSkipped(
@@ -43,8 +71,21 @@ class FileGetContentsTest extends \PHPUnit\Framework\TestCase
 
     public function testFetchFailed()
     {
+        self::startServer();
         $client = new FileGetContents('http://localhost:9999');
         $result = unserialize($client->fetch('does-not-exist'));
+
+        $this->assertIsArray($result);
+        $this->assertEquals(false, $result['result']);
+        $this->assertCount(1, $result['errors']);
+    }
+
+    public function testFetchRetryFailed(): void
+    {
+        self::stopServer();
+        self::startServer(0);
+        $client = new FileGetContents('http://localhost:9999', 1, 2);
+        $result = unserialize($client->fetch('README.md'));
 
         $this->assertIsArray($result);
         $this->assertEquals(false, $result['result']);

--- a/tests/Adapter/Http/SymfonyHttpClientTest.php
+++ b/tests/Adapter/Http/SymfonyHttpClientTest.php
@@ -7,30 +7,58 @@ use Symfony\Component\Process\Process;
 
 class SymfonyHttpClientTest extends \PHPUnit\Framework\TestCase
 {
-    /** @var Process */
-    private static $process;
+    private static ?Process $process = null;
 
-    public static function setUpBeforeClass(): void
+    private static function startServer(int $wait = 100000): void
     {
+        // Server is already running
+        if (self::$process instanceof Process) {
+            return;
+        }
+
         self::$process = new Process(['php', '-S', '127.0.0.1:9999', '-t', '.']);
         self::$process->start();
 
-        usleep(100000); //wait for server to get going
+        if ($wait) {
+            usleep($wait); //wait for server to get going
+        }
+    }
+
+    private static function stopServer(): void
+    {
+        // Do nothing if server is not running
+        if (!self::$process instanceof Process) {
+            return;
+        }
+
+        self::$process->stop();
+        self::$process = null;
     }
 
     public static function tearDownAfterClass(): void
     {
-        self::$process->stop();
+        // Make sure to stop server after all tests
+        self::stopServer();
     }
 
     public function testFetch()
     {
+        self::startServer();
         $client = new SymfonyHttpClient('http://localhost:9999');
+        $this->assertStringStartsWith('# CacheTool', $client->fetch('README.md'));
+    }
+
+    public function testFetchRetry(): void
+    {
+        self::stopServer();
+        self::startServer(0);
+        $client = new SymfonyHttpClient('http://localhost:9999', [], 10, 10);
         $this->assertStringStartsWith('# CacheTool', $client->fetch('README.md'));
     }
 
     public function testFetchUnderscores()
     {
+        self::startServer();
         $sslipHostname = '_.127.0.0.1.sslip.io';
         if (!gethostbynamel($sslipHostname)) {
             $this->markTestSkipped(
@@ -43,6 +71,7 @@ class SymfonyHttpClientTest extends \PHPUnit\Framework\TestCase
 
     public function testFetchFailed()
     {
+        self::startServer();
         $client = new SymfonyHttpClient('http://localhost:9999');
         $result = unserialize($client->fetch('does-not-exist'));
 
@@ -53,8 +82,21 @@ class SymfonyHttpClientTest extends \PHPUnit\Framework\TestCase
 
     public function testFetchInvalidUrl()
     {
+        self::startServer();
         $client = new SymfonyHttpClient('foo');
         $result = unserialize($client->fetch('bar'));
+
+        $this->assertIsArray($result);
+        $this->assertEquals(false, $result['result']);
+        $this->assertCount(1, $result['errors']);
+    }
+
+    public function testFetchRetryFailed(): void
+    {
+        self::stopServer();
+        self::startServer(0);
+        $client = new SymfonyHttpClient('http://localhost:9999', [], 1, 2);
+        $result = unserialize($client->fetch('README.md'));
 
         $this->assertIsArray($result);
         $this->assertEquals(false, $result['result']);


### PR DESCRIPTION
Due to implementation details in certain hosting setups, there can be a delay between creating the temporary cachetool file and it being accessible via HTTP. To address this, both FileGetContents and SymfonyHTTP clients are extended to retry HTTP requests on failure. By default, that new configuration option is set to `3`, which should cover most cases. However, its value can also be adjusted via CLI (`--web-retry`) or config file (`webRetry`).

The test setup is extended to cover both successful and failed retries. In the test setup, the availability delay of the php server is used to cover the mentioned test cases.

Resolves #209 